### PR TITLE
feat: add github webhook for on-demand cache revalidation

### DIFF
--- a/web/app/api/webhook/github/route.ts
+++ b/web/app/api/webhook/github/route.ts
@@ -1,0 +1,57 @@
+import { revalidateTag } from "next/cache";
+import { NextResponse } from "next/server";
+
+async function verifySignature(
+  payload: string,
+  signature: string | null,
+  secret: string,
+): Promise<boolean> {
+  if (!signature) return false;
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  const digest = "sha256=" + Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  // Constant-time comparison
+  if (digest.length !== signature.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < digest.length; i++) {
+    mismatch |= digest.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Webhook secret not configured" },
+      { status: 500 },
+    );
+  }
+
+  const body = await request.text();
+  const signature = request.headers.get("x-hub-signature-256");
+
+  const valid = await verifySignature(body, signature, secret);
+  if (!valid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const event = request.headers.get("x-github-event");
+  if (event === "release") {
+    revalidateTag("github-releases", "max");
+    return NextResponse.json({ revalidated: true });
+  }
+
+  return NextResponse.json({ ignored: true });
+}

--- a/web/app/changelog/page.tsx
+++ b/web/app/changelog/page.tsx
@@ -36,7 +36,7 @@ async function getReleases(): Promise<Release[]> {
           Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
         }),
       },
-      next: { revalidate: 300 },
+      next: { revalidate: 300, tags: ["github-releases"] },
     },
   );
   if (!res.ok) return [];

--- a/web/app/download/page.tsx
+++ b/web/app/download/page.tsx
@@ -27,7 +27,7 @@ async function getLatestDesktopRelease(): Promise<Release | null> {
           Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
         }),
       },
-      next: { revalidate: 300 },
+      next: { revalidate: 300, tags: ["github-releases"] },
     },
   );
   if (!res.ok) return null;


### PR DESCRIPTION
## Summary
This PR adds a GitHub webhook endpoint that listens for release events and triggers on-demand cache revalidation for GitHub release data, replacing the fixed 5-minute revalidation interval with real-time updates.

## Key Changes
- **New webhook endpoint** (`web/app/api/webhook/github/route.ts`):
  - Implements HMAC-SHA256 signature verification for GitHub webhook requests
  - Uses constant-time comparison to prevent timing attacks
  - Listens for GitHub release events and triggers cache revalidation via `revalidateTag()`
  - Returns appropriate error responses for missing secrets or invalid signatures

- **Updated cache tags** in data-fetching functions:
  - `web/app/changelog/page.tsx`: Added `"github-releases"` tag to release fetch
  - `web/app/download/page.tsx`: Added `"github-releases"` tag to latest release fetch
  - Both maintain the existing 5-minute revalidation interval as a fallback

## Implementation Details
- The webhook verifies GitHub's `x-hub-signature-256` header using the `GITHUB_WEBHOOK_SECRET` environment variable
- Only `release` events trigger cache revalidation; other events are ignored
- Uses Next.js `revalidateTag()` for targeted cache invalidation instead of full page revalidation
- Implements secure signature verification with bitwise comparison to prevent timing-based attacks

https://claude.ai/code/session_01DVpNfXz31iQPnNgZFGGzYu