### PR TITLE
fix: harden write command and improve cli error reporting

### DIFF
--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -23,7 +23,7 @@ export async function createCommand(
   const title = positionals[0];
   if (!title) throw new UsageError('Usage: wai create <title> [-c content | -f file | stdin] [-m summary]');
 
-  const content = resolveContent({
+  const content = await resolveContent({
     content: values.content as string | undefined,
     file: values.file as string | undefined,
   });

--- a/cli/src/commands/section.ts
+++ b/cli/src/commands/section.ts
@@ -105,7 +105,7 @@ async function sectionUpdate(
     throw new UsageError('Usage: wai section update <title> <section> [-c content | -f file | stdin] [-m summary]');
   }
 
-  const content = resolveContent({
+  const content = await resolveContent({
     content: values.content as string | undefined,
     file: values.file as string | undefined,
   });

--- a/cli/src/commands/source.ts
+++ b/cli/src/commands/source.ts
@@ -1,6 +1,8 @@
-import { UsageError } from '../errors.js';
+import { WaiError } from '../errors.js';
 import { type GlobalFlags, outputJson, outputTable } from '../output.js';
 import type { WikiClient } from '../wiki-client.js';
+
+const SUBCOMMANDS = ['list'] as const;
 
 export async function sourceCommand(
   args: string[],
@@ -9,7 +11,10 @@ export async function sourceCommand(
 ): Promise<void> {
   const sub = args[0];
   if (sub !== 'list') {
-    throw new UsageError('Usage: wai source list');
+    const hint = sub
+      ? `Unknown subcommand: "${sub}". Did you mean: ${SUBCOMMANDS.join(', ')}?`
+      : `Missing subcommand. Available: ${SUBCOMMANDS.join(', ')}`;
+    throw new WaiError(hint, 1);
   }
 
   const namespaces = await client.getNamespaces();

--- a/cli/src/commands/talk.ts
+++ b/cli/src/commands/talk.ts
@@ -71,7 +71,7 @@ async function talkCreate(args: string[], globals: GlobalFlags, client: WikiClie
     throw new UsageError('Usage: wai talk create <page> -s <subject> [-c content | -f file | stdin] [-m summary]');
   }
 
-  const content = resolveContent({
+  const content = await resolveContent({
     content: values.content as string | undefined,
     file: values.file as string | undefined,
   });

--- a/cli/src/commands/write.ts
+++ b/cli/src/commands/write.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'node:util';
 import { type WikiClient } from '../wiki-client.js';
-import { UsageError } from '../errors.js';
+import { UsageError, WaiError } from '../errors.js';
 import { resolveContent } from '../content.js';
 import { type GlobalFlags, outputJson, outputResult } from '../output.js';
 
@@ -21,14 +21,34 @@ export async function writeCommand(
   });
 
   const title = positionals[0];
-  if (!title) throw new UsageError('Usage: wai write <title> [-c content | -f file | stdin] [-m summary]');
+  if (!title) throw new UsageError('Usage: wai write <title> [-c content | -f file | -] [-m summary]');
 
-  const content = resolveContent({
+  // Support positional file arg: wai write "Title" file.txt
+  // Also support "-" as explicit stdin marker: wai write "Title" -
+  const fileArg = positionals[1];
+  const file = (values.file as string | undefined) ??
+    (fileArg && fileArg !== '-' ? fileArg : undefined);
+
+  const content = await resolveContent({
     content: values.content as string | undefined,
-    file: values.file as string | undefined,
+    file,
   });
 
+  if (!content.trim()) {
+    throw new WaiError('Refusing to write empty content. Use -c, -f, or pipe non-empty content to stdin.', 1);
+  }
+
   const result = await client.writePage(title, content, values.summary as string | undefined);
+
+  if (result.noChange) {
+    if (globals.json) {
+      outputJson(result);
+    } else {
+      console.error(`No changes to "${result.title}" (rev ${result.oldRevid})`);
+    }
+    process.exitCode = 1;
+    return;
+  }
 
   if (globals.json) {
     outputJson(result);

--- a/cli/src/content.ts
+++ b/cli/src/content.ts
@@ -2,14 +2,26 @@ import { readFileSync } from 'node:fs';
 import { UsageError } from './errors.js';
 
 /**
+ * Read all data from stdin as a stream (avoids EAGAIN on large pipes).
+ */
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+/**
  * Resolve content from -c flag, -f flag, or stdin.
  * Precedence: -c → -f → stdin (if not a TTY) → error
  */
-export function resolveContent(options: { content?: string; file?: string }): string {
+export async function resolveContent(options: { content?: string; file?: string }): Promise<string> {
   if (options.content !== undefined) return options.content;
   if (options.file) return readFileSync(options.file, 'utf-8');
   if (!process.stdin.isTTY) {
-    return readFileSync(0, 'utf-8');
+    return readStdin();
   }
   throw new UsageError('No content provided. Use -c, -f, or pipe to stdin.');
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -35,7 +35,7 @@ Usage:
 
 Pages:
   read <title>                Read a wiki page
-  write <title>               Write (overwrite) entire page
+  write <title> [file]         Write (overwrite) entire page
   edit <title>                Edit a page (find and replace)
   create <title>              Create a new page
   search <query>              Full-text search

--- a/cli/src/wiki-client.ts
+++ b/cli/src/wiki-client.ts
@@ -20,6 +20,7 @@ export interface EditResult {
   oldRevid: number;
   newRevid: number;
   timestamp: string;
+  noChange?: boolean;
 }
 
 export interface SearchResult {
@@ -174,11 +175,13 @@ export class WikiClient {
     const res = await this.client.post(this.api, new URLSearchParams(params));
     this.handleEditError(res.data);
     const edit = res.data.edit;
+    const noChange = edit.nochange !== undefined;
     return {
       title: edit.title,
       oldRevid,
-      newRevid: edit.newrevid ?? edit.oldrevid,
+      newRevid: noChange ? oldRevid : (edit.newrevid ?? oldRevid),
       timestamp: edit.newtimestamp ?? '',
+      noChange,
     };
   }
 

--- a/cli/test/content.test.ts
+++ b/cli/test/content.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveContent } from '../src/content.js';
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('resolveContent', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'wai-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true });
+  });
+
+  it('returns -c content when provided', async () => {
+    const result = await resolveContent({ content: 'inline content' });
+    assert.equal(result, 'inline content');
+  });
+
+  it('returns empty string from -c without error', async () => {
+    // resolveContent itself allows empty; the write command guards against it
+    const result = await resolveContent({ content: '' });
+    assert.equal(result, '');
+  });
+
+  it('reads content from -f file', async () => {
+    const filePath = join(tmp, 'test.txt');
+    writeFileSync(filePath, 'file content');
+
+    const result = await resolveContent({ file: filePath });
+    assert.equal(result, 'file content');
+  });
+
+  it('-c takes precedence over -f', async () => {
+    const filePath = join(tmp, 'test.txt');
+    writeFileSync(filePath, 'file content');
+
+    const result = await resolveContent({ content: 'inline', file: filePath });
+    assert.equal(result, 'inline');
+  });
+
+  it('throws on non-existent file', async () => {
+    await assert.rejects(
+      () => resolveContent({ file: '/nonexistent/path.txt' }),
+      { code: 'ENOENT' },
+    );
+  });
+
+  it('reads large file content', async () => {
+    const filePath = join(tmp, 'large.txt');
+    const largeContent = 'x'.repeat(100_000);
+    writeFileSync(filePath, largeContent);
+
+    const result = await resolveContent({ file: filePath });
+    assert.equal(result.length, 100_000);
+  });
+
+  it('throws UsageError when no source and stdin is TTY', async () => {
+    // When running tests, stdin is typically a TTY
+    if (process.stdin.isTTY) {
+      await assert.rejects(
+        () => resolveContent({}),
+        { name: 'UsageError' },
+      );
+    }
+  });
+});

--- a/cli/test/source.test.ts
+++ b/cli/test/source.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sourceCommand } from '../src/commands/source.js';
+import type { WikiClient } from '../src/wiki-client.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function mockClient(overrides: Partial<Record<string, any>> = {}): WikiClient {
+  return {
+    getNamespaces: async () => [{ id: 0, name: '' }],
+    listAllPages: async () => [],
+    ...overrides,
+  } as unknown as WikiClient;
+}
+
+const globals = { json: false, quiet: false };
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('sourceCommand', () => {
+  it('throws on unknown subcommand with "Did you mean" hint', async () => {
+    await assert.rejects(
+      () => sourceCommand(['foo'], globals, mockClient()),
+      (err: any) => {
+        assert.match(err.message, /Unknown subcommand: "foo"/);
+        assert.match(err.message, /Did you mean: list/);
+        assert.equal(err.exitCode, 1);
+        return true;
+      },
+    );
+  });
+
+  it('throws on missing subcommand with available list', async () => {
+    await assert.rejects(
+      () => sourceCommand([], globals, mockClient()),
+      (err: any) => {
+        assert.match(err.message, /Missing subcommand/);
+        assert.match(err.message, /Available: list/);
+        assert.equal(err.exitCode, 1);
+        return true;
+      },
+    );
+  });
+
+  it('lists source pages successfully', async () => {
+    const client = mockClient({
+      getNamespaces: async () => [{ id: 0, name: '' }, { id: 100, name: 'Source' }],
+      listAllPages: async () => ['Source:Page A', 'Source:Page B'],
+    });
+
+    // Should not throw
+    await sourceCommand(['list'], globals, client);
+  });
+
+  it('handles missing Source namespace gracefully', async () => {
+    const client = mockClient({
+      getNamespaces: async () => [{ id: 0, name: '' }],
+    });
+
+    // Should not throw
+    await sourceCommand(['list'], globals, client);
+  });
+});

--- a/cli/test/write.test.ts
+++ b/cli/test/write.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeCommand } from '../src/commands/write.js';
+import type { WikiClient } from '../src/wiki-client.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function mockClient(overrides: Partial<Record<string, any>> = {}): WikiClient {
+  return {
+    readPage: async () => ({ title: 'Test', revid: 100, content: 'old' }),
+    writePage: async (_t: string, _c: string) => ({
+      title: 'Test',
+      oldRevid: 100,
+      newRevid: 101,
+      timestamp: '2025-01-01',
+    }),
+    ...overrides,
+  } as unknown as WikiClient;
+}
+
+const globals = { json: false, quiet: false };
+const jsonGlobals = { json: true, quiet: false };
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('writeCommand', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'wai-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true });
+  });
+
+  it('throws UsageError when no title given', async () => {
+    await assert.rejects(
+      () => writeCommand([], globals, mockClient()),
+      { name: 'UsageError' },
+    );
+  });
+
+  it('rejects empty content from -c flag', async () => {
+    await assert.rejects(
+      () => writeCommand(['Test', '-c', ''], globals, mockClient()),
+      { message: /Refusing to write empty content/ },
+    );
+  });
+
+  it('rejects whitespace-only content from -c flag', async () => {
+    await assert.rejects(
+      () => writeCommand(['Test', '-c', '   \n  '], globals, mockClient()),
+      { message: /Refusing to write empty content/ },
+    );
+  });
+
+  it('rejects empty file content', async () => {
+    const filePath = join(tmp, 'empty.txt');
+    writeFileSync(filePath, '');
+
+    await assert.rejects(
+      () => writeCommand(['Test', '-f', filePath], globals, mockClient()),
+      { message: /Refusing to write empty content/ },
+    );
+  });
+
+  it('writes content from -c flag', async () => {
+    let written = '';
+    const client = mockClient({
+      writePage: async (_t: string, content: string) => {
+        written = content;
+        return { title: 'Test', oldRevid: 100, newRevid: 101, timestamp: '' };
+      },
+    });
+
+    await writeCommand(['Test', '-c', 'Hello world'], globals, client);
+    assert.equal(written, 'Hello world');
+  });
+
+  it('writes content from -f flag', async () => {
+    const filePath = join(tmp, 'page.txt');
+    writeFileSync(filePath, 'File content here');
+
+    let written = '';
+    const client = mockClient({
+      writePage: async (_t: string, content: string) => {
+        written = content;
+        return { title: 'Test', oldRevid: 100, newRevid: 101, timestamp: '' };
+      },
+    });
+
+    await writeCommand(['Test', '-f', filePath], globals, client);
+    assert.equal(written, 'File content here');
+  });
+
+  it('writes content from positional file arg', async () => {
+    const filePath = join(tmp, 'page.txt');
+    writeFileSync(filePath, 'Positional file content');
+
+    let written = '';
+    const client = mockClient({
+      writePage: async (_t: string, content: string) => {
+        written = content;
+        return { title: 'Test', oldRevid: 100, newRevid: 101, timestamp: '' };
+      },
+    });
+
+    await writeCommand(['Test', filePath], globals, client);
+    assert.equal(written, 'Positional file content');
+  });
+
+  it('-f flag takes precedence over positional file arg', async () => {
+    const flagFile = join(tmp, 'flag.txt');
+    const posFile = join(tmp, 'positional.txt');
+    writeFileSync(flagFile, 'from flag');
+    writeFileSync(posFile, 'from positional');
+
+    let written = '';
+    const client = mockClient({
+      writePage: async (_t: string, content: string) => {
+        written = content;
+        return { title: 'Test', oldRevid: 100, newRevid: 101, timestamp: '' };
+      },
+    });
+
+    await writeCommand(['Test', posFile, '-f', flagFile], globals, client);
+    assert.equal(written, 'from flag');
+  });
+
+  it('reports no-change edit with exit code 1', async () => {
+    const client = mockClient({
+      writePage: async () => ({
+        title: 'Test',
+        oldRevid: 100,
+        newRevid: 100,
+        timestamp: '',
+        noChange: true,
+      }),
+    });
+
+    const origExitCode = process.exitCode;
+    await writeCommand(['Test', '-c', 'same content'], globals, client);
+    assert.equal(process.exitCode, 1);
+    process.exitCode = origExitCode;
+  });
+
+  it('json output includes noChange for no-op edits', async () => {
+    const client = mockClient({
+      writePage: async () => ({
+        title: 'Test',
+        oldRevid: 100,
+        newRevid: 100,
+        timestamp: '',
+        noChange: true,
+      }),
+    });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+    const origExitCode = process.exitCode;
+
+    try {
+      await writeCommand(['Test', '-c', 'same content'], jsonGlobals, client);
+      const output = JSON.parse(logs[logs.length - 1]);
+      assert.equal(output.noChange, true);
+    } finally {
+      console.log = origLog;
+      process.exitCode = origExitCode;
+    }
+  });
+
+  it('passes summary to writePage', async () => {
+    let receivedSummary = '';
+    const client = mockClient({
+      writePage: async (_t: string, _c: string, summary: string) => {
+        receivedSummary = summary;
+        return { title: 'Test', oldRevid: 100, newRevid: 101, timestamp: '' };
+      },
+    });
+
+    await writeCommand(['Test', '-c', 'content', '-m', 'my summary'], globals, client);
+    assert.equal(receivedSummary, 'my summary');
+  });
+});


### PR DESCRIPTION
- Reject empty/whitespace-only content in write with a clear error (prevents silent page destruction)
- Detect no-op edits (rev: X → undefined) and exit non-zero with "No changes" message
- Switch stdin reading from readFileSync(0) to async streaming (fixes EAGAIN on large pipes)
- Support positional file arg: wai write "Title" file.txt
- Improve source subcommand errors: Unknown subcommand: "foo". Did you mean: list?