### PR TITLE
fix: remove active:scale animations from interactive components

### DIFF
--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -63,7 +63,7 @@ export function Footer() {
               setTheme(resolvedTheme === "dark" ? "light" : "dark")
             }
             className={cn(
-              "size-4.5 rounded-full cursor-pointer active:scale-95 focus:outline-3",
+              "size-4.5 rounded-full cursor-pointer focus:outline-3",
               {
                 "bg-amber-500 focus:outline-amber-500/50":
                   mounted && resolvedTheme === "light",

--- a/web/components/navbar.tsx
+++ b/web/components/navbar.tsx
@@ -30,7 +30,7 @@ function ThemeToggle() {
     <button
       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
       className={cn(
-        "size-4.5 rounded-full cursor-pointer active:scale-95 focus:outline-3",
+        "size-4.5 rounded-full cursor-pointer focus:outline-3",
         {
           "bg-amber-500 focus:outline-amber-500/50":
             mounted && resolvedTheme === "light",

--- a/web/components/ui/button.tsx
+++ b/web/components/ui/button.tsx
@@ -41,7 +41,7 @@ export function Button(props: Props) {
         }
       }}
       className={cn(
-        "flex flex-row gap-1 items-center w-fit h-fit px-3.5 py-2 cursor-pointer active:scale-98 select-none focus:outline-3 font-sans",
+        "flex flex-row gap-1 items-center w-fit h-fit px-3.5 py-2 cursor-pointer select-none focus:outline-3 font-sans",
         {
           "rounded-full": isCircular,
           "rounded-lg": !isCircular,


### PR DESCRIPTION
## Summary
Removed the `active:scale-95` and `active:scale-98` Tailwind CSS classes from interactive components to eliminate the scale-down animation that occurs when elements are actively clicked.

## Changes
- **Footer component**: Removed `active:scale-95` from theme toggle button
- **Navbar component**: Removed `active:scale-95` from theme toggle button  
- **Button component**: Removed `active:scale-98` from button styling

## Details
These changes simplify the interaction feedback by removing the visual scale animation on click. The components retain their other interactive states including focus outlines and cursor pointer styling, providing a cleaner user experience without the active state scaling effect.

https://claude.ai/code/session_013BRcC2UEYY9L8RyTrj4pUo