### PR TITLE
feat: enable macos code signing and notarization

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -37,11 +37,37 @@ jobs:
         run: bash scripts/bundle-lua.sh
         working-directory: desktop
 
+      - name: Import signing certificate
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+
+          echo "$CSC_LINK" | base64 --decode -o $CERTIFICATE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$CSC_KEY_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
+
       - name: Build
-        run: pnpm dist
+        run: pnpm dist -- --arm64 --x64
         working-directory: desktop
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Publish release
         run: gh release create "$GITHUB_REF_NAME" desktop/dist-electron/*.{dmg,zip} --title "$GITHUB_REF_NAME" --notes-file desktop/RELEASE_NOTES.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/signing.keychain-db

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -25,6 +25,8 @@ extraResources:
     to: resources/mediawiki
     filter:
       - "**/*"
+      - "!extensions/Scribunto/includes/Engines/LuaStandalone/binaries"
+      - "!tests"
   - from: resources/ffmpeg
     to: resources/ffmpeg
     filter:
@@ -38,6 +40,8 @@ extraResources:
     filter:
       - wai.cjs
 
+afterSign: scripts/notarize.cjs
+
 mac:
   category: public.app-category.productivity
   target:
@@ -45,7 +49,9 @@ mac:
     - zip
   icon: build/icon.icns
   darkModeSupport: true
-  identity: null
+  hardenedRuntime: true
+  strictVerify: false
+  notarize: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
 

--- a/desktop/scripts/notarize.cjs
+++ b/desktop/scripts/notarize.cjs
@@ -1,0 +1,37 @@
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+exports.default = async function notarize(context) {
+  if (context.electronPlatformName !== "darwin") return;
+
+  const appleId = process.env.APPLE_ID;
+  const password = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+  const teamId = process.env.APPLE_TEAM_ID;
+
+  if (!appleId || !password || !teamId) {
+    console.log("  • skipping notarization  reason=APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, or APPLE_TEAM_ID not set");
+    return;
+  }
+
+  // Prevent electron-builder from also attempting its built-in notarization
+  delete process.env.APPLE_TEAM_ID;
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  const zipPath = path.join(context.appOutDir, "notarize.zip");
+
+  console.log(`  • notarizing  app=${appName}.app`);
+
+  execSync(`ditto -c -k --keepParent "${appPath}" "${zipPath}"`);
+
+  try {
+    execSync(
+      `xcrun notarytool submit "${zipPath}" --apple-id "${appleId}" --password "${password}" --team-id "${teamId}" --wait`,
+      { stdio: "inherit" }
+    );
+    execSync(`xcrun stapler staple "${appPath}"`, { stdio: "inherit" });
+  } finally {
+    fs.rmSync(zipPath, { force: true });
+  }
+};


### PR DESCRIPTION
## Summary
  - Sign the desktop app with the Developer ID Application certificate (auto-detected from Keychain)
  - Notarize via a custom `afterSign` hook that calls `xcrun notarytool` directly, bypassing
  `@electron/notarize`'s broken `--deep --strict` pre-check on Electron apps
  - Import the signing certificate into a temporary keychain on CI and clean up after
  - Exclude Scribunto's old Lua binary (pre-10.9 SDK) and MediaWiki test data from the bundle, which
  Apple rejects
  - Build both arm64 and x64 artifacts on CI

  ## Notes
  - Notarization requires `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `CSC_LINK`, and
  `CSC_KEY_PASSWORD` as GitHub secrets
  - Apple's notarization service is currently experiencing delays — signing is verified working,
  notarization will work once their service recovers