### PR TITLE
feat: non-blocking notarization via apple rest api

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -65,10 +65,10 @@ jobs:
           ulimit -n 65536
           pnpm dist -- --arm64 --x64
         working-directory: desktop
-        # env:
-        #   APPLE_ID: ${{ secrets.APPLE_ID }}
-        #   APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-        #   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
 
       - name: Publish release
         run: gh release create "$GITHUB_REF_NAME" desktop/dist-electron/*.{dmg,zip} --title "$GITHUB_REF_NAME" --notes-file desktop/RELEASE_NOTES.md

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "aws4": "^1.13.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.5.2",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      aws4:
+        specifier: ^1.13.2
+        version: 1.13.2
       electron:
         specifier: 33.4.11
         version: 33.4.11
@@ -769,6 +772,9 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2852,6 +2858,8 @@ snapshots:
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
+
+  aws4@1.13.2: {}
 
   balanced-match@1.0.2: {}
 

--- a/desktop/scripts/notarize.cjs
+++ b/desktop/scripts/notarize.cjs
@@ -1,21 +1,21 @@
 const { execSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
+const crypto = require("crypto");
+const https = require("https");
+const aws4 = require("aws4");
 
 exports.default = async function notarize(context) {
   if (context.electronPlatformName !== "darwin") return;
 
-  const appleId = process.env.APPLE_ID;
-  const password = process.env.APPLE_APP_SPECIFIC_PASSWORD;
-  const teamId = process.env.APPLE_TEAM_ID;
+  const keyId = process.env.ASC_KEY_ID;
+  const issuerId = process.env.ASC_ISSUER_ID;
+  const privateKeyBase64 = process.env.ASC_PRIVATE_KEY;
 
-  if (!appleId || !password || !teamId) {
-    console.log("  • skipping notarization  reason=APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, or APPLE_TEAM_ID not set");
+  if (!keyId || !issuerId || !privateKeyBase64) {
+    console.log("  • skipping notarization  reason=ASC_KEY_ID, ASC_ISSUER_ID, or ASC_PRIVATE_KEY not set");
     return;
   }
-
-  // Prevent electron-builder from also attempting its built-in notarization
-  delete process.env.APPLE_TEAM_ID;
 
   const appName = context.packager.appInfo.productFilename;
   const appPath = path.join(context.appOutDir, `${appName}.app`);
@@ -26,34 +26,140 @@ exports.default = async function notarize(context) {
   execSync(`ditto -c -k --keepParent "${appPath}" "${zipPath}"`);
 
   try {
-    const result = execSync(
-      `xcrun notarytool submit "${zipPath}" --apple-id "${appleId}" --password "${password}" --team-id "${teamId}" --wait`,
-      { stdio: "pipe", encoding: "utf-8" }
-    );
-    process.stdout.write(result);
+    const privateKey = crypto.createPrivateKey({
+      key: Buffer.from(privateKeyBase64, "base64"),
+      format: "pem",
+    });
 
-    // Extract submission ID for potential log retrieval
-    const idMatch = result.match(/id:\s*([0-9a-f-]+)/);
-    const submissionId = idMatch ? idMatch[1] : null;
+    const jwt = signJWT(keyId, issuerId, privateKey);
+    const zipData = fs.readFileSync(zipPath);
+    const sha256 = crypto.createHash("sha256").update(zipData).digest("hex");
 
-    if (result.includes("status: Invalid") || result.includes("status: Rejected")) {
-      if (submissionId) {
-        console.log("\n  • fetching notarization log...");
-        try {
-          const log = execSync(
-            `xcrun notarytool log "${submissionId}" --apple-id "${appleId}" --password "${password}" --team-id "${teamId}"`,
-            { encoding: "utf-8" }
-          );
-          console.log(log);
-        } catch (e) {
-          console.log("  • failed to fetch notarization log:", e.message);
-        }
-      }
-      throw new Error("Notarization failed with status: Invalid");
-    }
+    // Submit to Apple Notary API
+    const submission = await apiRequest("POST", "/notary/v2/submissions", jwt, {
+      submissionName: `${appName}.zip`,
+      sha256,
+    });
 
-    execSync(`xcrun stapler staple "${appPath}"`, { stdio: "inherit" });
+    const { id } = submission.data;
+    const { bucket, object, accessKeyId, secretAccessKey, sessionToken } =
+      submission.data.attributes;
+
+    console.log(`  • notarization submitted  id=${id}`);
+
+    // Upload zip to S3
+    await s3Upload(zipData, {
+      bucket,
+      key: object,
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+    });
+
+    console.log(`  • uploaded to S3  submission=${id}`);
+    console.log(`  • notarization in progress — not waiting for Apple's verdict`);
+    console.log(`  • check status: xcrun notarytool info ${id} --key <p8> --key-id ${keyId} --issuer ${issuerId}`);
   } finally {
     fs.rmSync(zipPath, { force: true });
   }
 };
+
+// --- JWT ---
+
+function signJWT(keyId, issuerId, privateKey) {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "ES256", kid: keyId, typ: "JWT" })
+  ).toString("base64url");
+
+  const now = Math.floor(Date.now() / 1000);
+  const payload = Buffer.from(
+    JSON.stringify({ iss: issuerId, iat: now, exp: now + 1200, aud: "appstoreconnect-v1" })
+  ).toString("base64url");
+
+  const sig = crypto
+    .sign("SHA256", Buffer.from(`${header}.${payload}`), {
+      key: privateKey,
+      dsaEncoding: "ieee-p1363",
+    })
+    .toString("base64url");
+
+  return `${header}.${payload}.${sig}`;
+}
+
+// --- Apple Notary REST API ---
+
+function apiRequest(method, apiPath, jwt, body) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const req = https.request(
+      {
+        hostname: "appstoreconnect.apple.com",
+        path: apiPath,
+        method,
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString();
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`Notary API ${res.statusCode}: ${text}`));
+            return;
+          }
+          resolve(JSON.parse(text));
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end(data);
+  });
+}
+
+// --- S3 upload ---
+
+function s3Upload(body, { bucket, key, accessKeyId, secretAccessKey, sessionToken }) {
+  return new Promise((resolve, reject) => {
+    const signed = aws4.sign(
+      {
+        service: "s3",
+        region: "us-west-2",
+        method: "PUT",
+        path: `/${key}`,
+        host: `${bucket}.s3.us-west-2.amazonaws.com`,
+        headers: {
+          "Content-Length": body.length,
+          "Content-Type": "application/zip",
+        },
+        body,
+      },
+      { accessKeyId, secretAccessKey, sessionToken }
+    );
+
+    const req = https.request(
+      {
+        hostname: signed.host,
+        path: signed.path,
+        method: "PUT",
+        headers: signed.headers,
+      },
+      (res) => {
+        let chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`S3 upload ${res.statusCode}: ${Buffer.concat(chunks).toString()}`));
+            return;
+          }
+          resolve();
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+}


### PR DESCRIPTION
**Description:**

## Summary
- Replace `xcrun notarytool submit --wait` with direct calls to Apple's Notary REST API
- Submit for notarization and continue immediately — no more waiting 5+ minutes for Apple's verdict
- Gatekeeper checks the notarization ticket online, so stapling isn't needed

## Changes
- **`desktop/scripts/notarize.cjs`** — Rewrite: JWT (ES256) via native `crypto`, POST to `/notary/v2/submissions`, upload zip to S3 via `aws4`, return immediately
- **`desktop/package.json`** — Add `aws4` devDependency (zero-dep SigV4 signing)
- **`.github/workflows/release-desktop.yml`** — Replace `APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID` env vars with `ASC_KEY_ID`/`ASC_ISSUER_ID`/`ASC_PRIVATE_KEY`