### PR TITLE
chore: clarify cli commands and installation steps

### DIFF
--- a/web/content/docs/installation.mdx
+++ b/web/content/docs/installation.mdx
@@ -29,10 +29,10 @@ After installation, the app will:
 3. Verify everything is connected
 
 ```bash
-wai status
+wai auth status
 ```
 
-You should see confirmation that both the wiki and CLI are ready.
+You should see confirmation that the CLI is connected to the wiki.
 
 ## Install the agent harness plugin
 
@@ -40,33 +40,31 @@ The agent harness connects your AI coding tool to your wiki. Install the plugin 
 
 ### Claude Code
 
-```bash
-wai plugin install claude-code
-```
-
-This registers the whoami.wiki MCP server with Claude Code, giving it access to wiki tools.
-
-### Codex
+Install the whoami plugin from the Claude Code plugin marketplace:
 
 ```bash
-wai plugin install codex
+claude plugin add whoami
 ```
 
-### OpenCode
+This gives Claude Code access to wiki tools through the `wai` CLI.
 
-```bash
-wai plugin install opencode
-```
+### Codex / OpenCode
+
+These tools can use the `wai` CLI directly. Ensure the `wai` binary is in your PATH and run `wai auth login` to authenticate before starting a session.
 
 ## Verify the setup
 
 Run a quick check to confirm everything is connected:
 
 ```bash
-wai doctor
+wai auth status
 ```
 
-This verifies the wiki is running, the CLI is installed, and the agent harness can communicate with both.
+This verifies the CLI can connect to the wiki. You can also try a quick search to confirm everything is working end-to-end:
+
+```bash
+wai search "test"
+```
 
 ## Next steps
 

--- a/web/content/docs/troubleshooting.mdx
+++ b/web/content/docs/troubleshooting.mdx
@@ -7,19 +7,21 @@ Common issues and how to fix them.
 
 ## Wiki not starting
 
-**Symptom**: `wai status` shows the wiki as offline, or `http://localhost:8080` is unreachable.
+**Symptom**: `wai auth status` shows the wiki as offline, or `http://localhost:8080` is unreachable.
 
-**Fix**: Make sure Docker is running, then restart the wiki:
-
-```bash
-wai wiki restart
-```
-
-If the port is already in use, you can change it:
+**Fix**: Make sure Docker is running, then restart the wiki from the desktop app or by restarting the Docker container directly:
 
 ```bash
-wai config set wiki.port 8081
+docker restart whoami-wiki
 ```
+
+If the port is already in use, you can change it in `~/.whoami/config.json`:
+
+```json
+{ "wiki": { "port": 8081 } }
+```
+
+Then restart the wiki for the change to take effect.
 
 ## CLI not found in PATH
 
@@ -38,19 +40,20 @@ Add this line to your shell profile (`~/.zshrc`, `~/.bashrc`) to make it permane
 
 **Symptom**: The agent can't find whoami.wiki tools or returns connection errors when trying to use them.
 
-**Fix**: Verify the plugin is installed and the wiki is reachable:
+**Fix**: Verify the CLI can reach the wiki:
 
 ```bash
-wai doctor
+wai auth status
 ```
 
-If the plugin is installed but not detected, try reinstalling:
+If the plugin is installed but not detected, try removing and re-adding it:
 
 ```bash
-wai plugin install claude-code --force
+claude plugin remove whoami
+claude plugin add whoami
 ```
 
-Make sure you restart your agent harness after installing the plugin.
+Make sure you restart your agent session after reinstalling the plugin.
 
 ## Permission errors on snapshot
 
@@ -68,18 +71,19 @@ On macOS, you may need to grant terminal access to the Photos directory in Syste
 
 **Symptom**: `wai snapshot` takes a very long time or your machine runs out of memory with large data sets.
 
-**Fix**: Process in smaller batches:
+**Fix**: Process smaller directories at a time instead of one large snapshot:
 
 ```bash
-wai snapshot ~/Photos/grandma/2020 --batch-size 100
+wai snapshot ~/Photos/grandma/2020
+wai snapshot ~/Photos/grandma/2021
 ```
 
 ## Still stuck?
 
-Run diagnostics and include the output when reporting an issue:
+Check your connection status and include the output when reporting an issue:
 
 ```bash
-wai doctor --verbose
+wai auth status --json
 ```
 
 File issues at [github.com/whoami-wiki/whoami/issues](https://github.com/whoami-wiki/whoami/issues).


### PR DESCRIPTION
## Summary
Updated troubleshooting and installation documentation to reflect current CLI commands and workflows. Changes clarify the actual commands users should run and simplify plugin installation instructions.

## Key Changes
- **CLI command updates**: Changed references from `wai status` to `wai auth status` and `wai doctor` to `wai auth status` throughout docs
- **Wiki restart instructions**: Updated from `wai wiki restart` to `docker restart whoami-wiki` with note about desktop app alternative
- **Port configuration**: Changed from CLI command (`wai config set`) to direct JSON file editing in `~/.whoami/config.json`
- **Plugin installation**: Simplified Claude Code plugin installation to use `claude plugin add whoami` instead of `wai plugin install`
- **Agent harness support**: Clarified that Codex/OpenCode use the `wai` CLI directly rather than requiring plugin installation
- **Snapshot troubleshooting**: Removed `--batch-size` flag and instead recommend processing smaller directories separately
- **Diagnostics**: Changed from `wai doctor --verbose` to `wai auth status --json` for issue reporting
- **Verification steps**: Updated setup verification to use `wai search "test"` as end-to-end confirmation

## Notable Details
- Documentation now aligns with actual CLI interface and Docker-based deployment
- Removed references to deprecated plugin installation mechanism
- Clarified distinction between wiki restart methods (desktop app vs. Docker)
- Simplified troubleshooting guidance to focus on connection status verification

https://claude.ai/code/session_01N8y5NvPfDXDtvoQkXThCTz