### PR TITLE
feat: bundle static php for signed macos releases

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: desktop
 
       - name: Build PHP
-        run: bash scripts/build-php.sh
+        run: bash scripts/build-php.sh --static
         working-directory: desktop
 
       - name: Bundle MediaWiki
@@ -38,7 +38,7 @@ jobs:
         working-directory: desktop
 
       - name: Bundle ffmpeg
-        run: bash scripts/bundle-ffmpeg.sh
+        run: bash scripts/bundle-ffmpeg.sh --static
         working-directory: desktop
 
       - name: Import signing certificate

--- a/desktop/scripts/build-php.sh
+++ b/desktop/scripts/build-php.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # Get a PHP binary with extensions needed for MediaWiki.
 #
-# For local development: uses Homebrew PHP (php 8.x with needed extensions).
-# For CI/release builds: uses static-php-cli to compile a static binary.
+# Usage:
+#   bash build-php.sh           # Dev: symlink to Homebrew PHP
+#   bash build-php.sh --static  # Dist: compile a static binary via static-php-cli
 #
 # Output: resources/php/bin/php
 
@@ -12,16 +13,76 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
 OUT="$ROOT/resources/php"
 
+STATIC=false
+for arg in "$@"; do
+  case "$arg" in
+    --static) STATIC=true ;;
+  esac
+done
+
 if [ -f "$OUT/bin/php" ]; then
-  echo "PHP binary already exists at $OUT/bin/php — skipping"
-  "$OUT/bin/php" -v
-  exit 0
+  # For --static, replace any symlink with a real binary
+  if [ "$STATIC" = true ] && [ -L "$OUT/bin/php" ]; then
+    echo "==> Removing dev symlink (need static binary for distribution)..."
+    rm "$OUT/bin/php"
+  else
+    echo "PHP binary already exists at $OUT/bin/php — skipping"
+    "$OUT/bin/php" -v
+    exit 0
+  fi
 fi
 
 mkdir -p "$OUT/bin"
 
-# ── Strategy 1: Use Homebrew PHP (local dev on macOS) ────────────────────
+# ── Static binary for distribution (macOS) ─────────────────────────────
 
+if [ "$STATIC" = true ]; then
+  EXTENSIONS="sqlite3,pdo_sqlite,mbstring,xml,gd,intl,curl,fileinfo"
+  ARCH="$(uname -m)"
+
+  # Map uname arch to static-php-cli naming
+  case "$ARCH" in
+    arm64) SPC_ARCH="aarch64" ;;
+    *)     SPC_ARCH="$ARCH" ;;
+  esac
+
+  echo "==> Building static PHP for macOS ($ARCH) with extensions: $EXTENSIONS"
+
+  BUILD_DIR="$ROOT/.build/php-static"
+  mkdir -p "$BUILD_DIR"
+
+  # Download spc (static-php-cli) binary
+  SPC="$BUILD_DIR/spc"
+  if [ ! -f "$SPC" ]; then
+    TARBALL="$BUILD_DIR/spc-macos-$SPC_ARCH.tar.gz"
+    echo "==> Downloading static-php-cli..."
+    curl -fSL -o "$TARBALL" \
+      "https://github.com/crazywhalecc/static-php-cli/releases/latest/download/spc-macos-$SPC_ARCH.tar.gz"
+    tar -xzf "$TARBALL" -C "$BUILD_DIR"
+    chmod +x "$SPC"
+    rm "$TARBALL"
+  fi
+
+  # Download PHP sources and extension dependencies
+  echo "==> Downloading PHP 8.3 sources..."
+  "$SPC" download --with-php=8.3 --for-extensions="$EXTENSIONS" --prefer-pre-built
+
+  # Build static PHP CLI
+  echo "==> Compiling static PHP CLI..."
+  "$SPC" build "$EXTENSIONS" --build-cli
+
+  # Copy the resulting binary
+  cp buildroot/bin/php "$OUT/bin/php"
+  chmod +x "$OUT/bin/php"
+
+  echo "==> Static PHP ready at $OUT/bin/php"
+  "$OUT/bin/php" -v
+  exit 0
+fi
+
+# ── Dev mode: symlink to Homebrew/system PHP ───────────────────────────
+
+# Strategy 1: Use Homebrew PHP (local dev on macOS)
 if command -v brew &>/dev/null; then
   # Try php 8.3 first, then any php
   for formula in php@8.3 php; do
@@ -52,8 +113,7 @@ if command -v brew &>/dev/null; then
   done
 fi
 
-# ── Strategy 2: System PHP ───────────────────────────────────────────────
-
+# Strategy 2: System PHP
 if command -v php &>/dev/null; then
   SYSTEM_PHP="$(command -v php)"
   PHP_VERSION="$(php -r 'echo PHP_MAJOR_VERSION;' 2>/dev/null)"
@@ -68,8 +128,7 @@ if command -v php &>/dev/null; then
   fi
 fi
 
-# ── Strategy 3: Install via Homebrew ─────────────────────────────────────
-
+# Strategy 3: Install via Homebrew
 if command -v brew &>/dev/null; then
   echo "==> No PHP found. Installing via Homebrew..."
   brew install php


### PR DESCRIPTION
## Summary

- Add `--static` mode to `build-php.sh` that uses [static-php-cli](https://github.com/crazywhalecc/static-php-cli) to compile a fully static PHP 8.3 binary with all required extensions (`sqlite3`, `pdo_sqlite`, `mbstring`, `xml`, `gd`, `intl`, `curl`, `fileinfo`)
- Pass `--static` to both `build-php.sh` and `bundle-ffmpeg.sh` in the release workflow so CI produces real binaries instead of symlinks

## Context

The released app bundled a symlink to Homebrew PHP. When the code-signed app launched PHP, macOS hardened runtime rejected Homebrew's `libtidy` (different Team ID), crashing the app. A static binary has no third-party dylib dependencies, avoiding this entirely.

## Test plan

- [ ] Run `bash scripts/build-php.sh --static` locally
- [ ] Verify `resources/php/bin/php` is a Mach-O binary: `file resources/php/bin/php`
- [ ] Verify no Homebrew dylib deps: `otool -L resources/php/bin/php`
- [ ] Verify extensions: `resources/php/bin/php -m` includes all 8 required extensions
- [ ] Run `pnpm dist` and launch the app — wiki should load
- [ ] Push a release tag and verify CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)