### PR TITLE
feat: add sitemap.xml to web

### DIFF
--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+import { getAllPosts } from "@/lib/blog";
+import { getAllDocs } from "@/lib/docs";
+
+const BASE_URL = "https://whoami.wiki";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getAllPosts();
+  const docs = getAllDocs();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: BASE_URL, lastModified: new Date(), changeFrequency: "weekly", priority: 1 },
+    { url: `${BASE_URL}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE_URL}/docs`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE_URL}/download`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE_URL}/changelog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.6 },
+  ];
+
+  const blogRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${BASE_URL}/blog/${post.slug}`,
+    lastModified: post.date ? new Date(post.date) : new Date(),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  const docRoutes: MetadataRoute.Sitemap = docs.map((doc) => ({
+    url: `${BASE_URL}/docs/${doc.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...blogRoutes, ...docRoutes];
+}


### PR DESCRIPTION
## Summary
Added a dynamic sitemap generation file to improve SEO and help search engines discover and index all pages on the site.

## Key Changes
- Created `web/app/sitemap.ts` that generates a comprehensive sitemap including:
  - Static routes (home, blog index, docs index, download, changelog)
  - Dynamic blog post routes pulled from `getAllPosts()`
  - Dynamic documentation routes pulled from `getAllDocs()`
- Configured appropriate metadata for each route type:
  - Home page: weekly change frequency, priority 1.0
  - Blog and docs indexes: weekly frequency, priority 0.8
  - Individual blog posts: monthly frequency, priority 0.7
  - Individual docs: weekly frequency, priority 0.7
  - Download page: monthly frequency, priority 0.9
  - Changelog: weekly frequency, priority 0.6

## Implementation Details
- Uses Next.js `MetadataRoute.Sitemap` type for proper typing
- Base URL configured as `https://whoami.wiki`
- Blog posts use their actual publication dates for `lastModified` when available
- Dynamically fetches all posts and docs to ensure the sitemap stays current
- Combines static and dynamic routes into a single sitemap array

https://claude.ai/code/session_01AeWEtRr8C9JYApQf7oFjvv