### PR TITLE
feat: disable dynamic params and statically generate docs pages in web

### DIFF
--- a/web/app/changelog/page.tsx
+++ b/web/app/changelog/page.tsx
@@ -16,18 +16,23 @@ interface Release {
 }
 
 async function getReleases(): Promise<Release[]> {
-  const res = await fetch(
-    `https://api.github.com/repos/${REPO}/releases?per_page=50`,
-    {
-      headers: {
-        Accept: "application/vnd.github.v3+json",
-        ...(process.env.GITHUB_TOKEN && {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-        }),
+  let res: Response;
+  try {
+    res = await fetch(
+      `https://api.github.com/repos/${REPO}/releases?per_page=50`,
+      {
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          ...(process.env.GITHUB_TOKEN && {
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          }),
+        },
+        next: { revalidate: 300, tags: ["github-releases"] },
       },
-      next: { revalidate: 300, tags: ["github-releases"] },
-    },
-  );
+    );
+  } catch {
+    return [];
+  }
   if (!res.ok) return [];
   const all: Release[] = await res.json();
   return all

--- a/web/app/docs/[slug]/page.tsx
+++ b/web/app/docs/[slug]/page.tsx
@@ -61,6 +61,8 @@ interface Props {
   params: Promise<{ slug: string }>;
 }
 
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
   return getAllDocs().map((doc) => ({ slug: doc.slug }));
 }

--- a/web/app/download/page.tsx
+++ b/web/app/download/page.tsx
@@ -20,15 +20,20 @@ interface Release {
 }
 
 async function getLatestDesktopRelease(): Promise<Release | null> {
-  const res = await fetch(`https://api.github.com/repos/${REPO}/releases`, {
-    headers: {
-      Accept: "application/vnd.github.v3+json",
-      ...(process.env.GITHUB_TOKEN && {
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-      }),
-    },
-    next: { revalidate: 300, tags: ["github-releases"] },
-  });
+  let res: Response;
+  try {
+    res = await fetch(`https://api.github.com/repos/${REPO}/releases`, {
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        ...(process.env.GITHUB_TOKEN && {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        }),
+      },
+      next: { revalidate: 300, tags: ["github-releases"] },
+    });
+  } catch {
+    return null;
+  }
   if (!res.ok) return null;
   const releases: Release[] = await res.json();
   return releases.find((r) => r.tag_name.startsWith("desktop-v")) ?? null;


### PR DESCRIPTION
## Summary
This PR improves error handling for GitHub API requests and optimizes static generation for documentation pages.

## Key Changes
- **Error handling for GitHub API calls**: Wrapped `fetch` calls in try-catch blocks in both `changelog/page.tsx` and `download/page.tsx` to gracefully handle network errors and return appropriate fallback values (empty array for changelog, null for download page)
- **Disable dynamic params for docs**: Added `export const dynamicParams = false` to `docs/[slug]/page.tsx` to ensure only pre-generated static pages are served, preventing 404s for non-existent documentation slugs

## Implementation Details
- The try-catch blocks catch any errors that occur during the fetch operation itself (network failures, timeouts, etc.), complementing the existing `!res.ok` checks that handle HTTP error responses
- Setting `dynamicParams = false` in the docs page ensures that only documentation pages generated by `generateStaticParams()` are accessible, improving performance and preventing unexpected dynamic route generation

https://claude.ai/code/session_0121LKYEMLB73EcKDGH1tmLx