### PR TITLE
feat: add scrollable overflow to sidebar and table of contents

### DIFF
--- a/web/components/docs-sidebar.tsx
+++ b/web/components/docs-sidebar.tsx
@@ -44,7 +44,7 @@ export function DocsSidebar({ sections }: { sections: SidebarSection[] }) {
   const activeHeadingId = useActiveHeading(headingIds);
 
   return (
-    <nav className="w-56 shrink-0 font-sans text-sm">
+    <nav className="w-56 shrink-0 font-sans text-sm max-h-[calc(100dvh-5rem)] overflow-y-auto">
       <div className="flex flex-col gap-6">
         {sections.map((section) => (
           <div key={section.title} className="flex flex-col gap-1">

--- a/web/components/table-of-contents.tsx
+++ b/web/components/table-of-contents.tsx
@@ -31,7 +31,7 @@ export function TableOfContents({ headings }: { headings: TocHeading[] }) {
   if (headings.length === 0) return null;
 
   return (
-    <nav className="sticky top-24 w-56">
+    <nav className="sticky top-24 w-56 max-h-[calc(100dvh-7rem)] overflow-y-auto">
       <div className="font-sans text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-3">
         On this page
       </div>


### PR DESCRIPTION
## Summary
Added vertical scrolling capability to the documentation sidebar and table of contents components to prevent content overflow on smaller viewports.

## Changes
- **DocsSidebar**: Added `max-h-[calc(100dvh-5rem)] overflow-y-auto` to enable scrolling when content exceeds viewport height, accounting for header spacing
- **TableOfContents**: Added `max-h-[calc(100dvh-7rem)] overflow-y-auto` to enable scrolling with appropriate height constraints for the sticky positioned element

## Implementation Details
- Used `100dvh` (dynamic viewport height) for better mobile browser compatibility
- Calculated max-heights account for fixed header heights (5rem for sidebar, 7rem for TOC)
- Both components now gracefully handle overflow content while maintaining sticky positioning behavior

https://claude.ai/code/session_01Xz7A9tQgSy5UmCrj9QcDQf