### PR TITLE
feat: separate codex and opencode installation guides

### DIFF
--- a/web/content/docs/installation.mdx
+++ b/web/content/docs/installation.mdx
@@ -28,11 +28,11 @@ The agent harness connects your AI coding tool to your wiki. Install the extensi
 
 ### Claude Code
 
-Add the whoami marketplace and install the plugin:
+Add the whoami marketplace and install the plugin. Run these slash commands inside Claude Code:
 
-```bash
-claude marketplace add whoami-wiki/extensions
-claude plugin add whoami
+```
+/plugin marketplace add whoami-wiki/extensions
+/plugin install whoami@whoami-marketplace
 ```
 
 This installs the editor agent, editorial guide, and gives Claude Code access to wiki tools through the `wai` CLI.


### PR DESCRIPTION
## Summary
- Split the combined "Codex / OpenCode" section into separate installation guides for each harness
- Add accurate step-by-step instructions based on the actual extension structures in the [extensions repo](https://github.com/whoami-wiki/extensions)
- Codex: copy `.agents/` directory with editor agent YAML and editorial guide skill
- OpenCode: copy `.opencode/` directory with instructions, TypeScript plugin, and `opencode.json`

## Test plan
- [ ] Verify the installation page renders correctly
- [ ] Confirm code blocks and links display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)