### PR TITLE
feat: add reader reaction to personal encyclopedia blog post

### DIFF
--- a/web/content/blog/personal-encyclopedias.mdx
+++ b/web/content/blog/personal-encyclopedias.mdx
@@ -76,6 +76,8 @@ So I started pointing Claude Code at other data exports. My Facebook, Instagram,
 
 The model traced the arc of our friendships through the messages, pulled out the life episodes we had talked each other through, and wove them into multiple pages that read like it was written by someone who knew us both.
 
+When I shared the pages with the friends involved, they wanted to read every single one.
+
 <WideImage light="/blog/10-light.png" dark="/blog/10-light.png"/>
 
 This is when I realized I was no longer working on a family history project. What I had been building, page by page, was a personal encyclopedia. A structured, browsable, interconnected account of my life compiled from the data I already had lying around.


### PR DESCRIPTION
## Summary
Added a sentence to the personal encyclopedias blog post that highlights the positive reception from friends when the generated pages were shared with them.

## Changes
- Added a new paragraph after the description of the AI-generated friendship pages that notes friends' enthusiastic response to reading the content
- This addition emphasizes the value and appeal of the personal encyclopedia concept by showing real-world validation from the intended audience

## Details
The new sentence ("When I shared the pages with the friends involved, they wanted to read every single one.") serves as a narrative bridge that reinforces the significance of the project before the visual element and the realization that this had evolved into a personal encyclopedia rather than just a family history project.

https://claude.ai/code/session_0153Y6C4o8FSLNRRkA61qUiK