### PR TITLE
chore: update homepage cta button to link to docs instead of download

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -16,8 +16,8 @@ export default function Home() {
           </div>
 
           <div className="flex flex-row gap-2">
-            <Link href="/download" tabIndex={-1}>
-              <Button text="Download Now" accent="primary" isCircular />
+            <Link href="/docs" tabIndex={-1}>
+              <Button text="Get Started" accent="primary" isCircular />
             </Link>
             <Link href="/blog/personal-encyclopedias" tabIndex={-1}>
               <Button text="Read Essay" accent="secondary" isCircular />


### PR DESCRIPTION
## Summary
Updated the primary call-to-action button on the homepage to direct users to the documentation instead of a download page, with corresponding button text change.

## Changes
- Changed primary CTA link destination from `/download` to `/docs`
- Updated button text from "Download Now" to "Get Started" to better reflect the new destination and user flow

## Details
This change redirects users to the documentation/getting started guide as the primary action, which likely provides a better onboarding experience than a direct download link. The button text has been updated accordingly to set proper user expectations.

https://claude.ai/code/session_017u8kZ5CfLwHUhcmCWbuodn