### PR TITLE
feat: add eval suite for editorial agents

### DIFF
--- a/.claude/skills/create-fixture/SKILL.md
+++ b/.claude/skills/create-fixture/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: create-fixture
+description: Create a new eval fixture for whoami.wiki from the user's personal archive data
+triggers: ["create-fixture", "new fixture", "add fixture"]
+user_invocable: true
+---
+
+# Create Fixture
+
+Interactively create a new eval fixture for the whoami.wiki evaluation suite.
+
+## Usage
+
+`/create-fixture [page-type]`
+
+Examples:
+- `/create-fixture` — start interactive fixture creation
+- `/create-fixture person` — create a person page fixture
+- `/create-fixture episode` — create an episode page fixture
+- `/create-fixture project` — create a project page fixture
+
+## Steps
+
+### 1. Determine page type
+
+If no page type was provided as an argument, ask the user:
+
+> What type of page is this fixture for?
+> - **Person** — a biography of someone in your archive (friend, family, colleague)
+> - **Episode** — a specific event, trip, or milestone
+> - **Project** — a software project, creative work, or collaborative effort
+
+### 2. Gather basic information
+
+Ask the user for:
+
+- **Subject name**: The primary subject (e.g., "Sarah Kim", "Tokyo trip", "Raycast plugin")
+- **Description**: One sentence describing the eval task
+- **Suite name**: Which suite to place this in (default: `incremental`)
+
+### 3. Identify data sources
+
+Ask the user what archive data they have available for this subject. For each source, collect:
+
+- **Path**: Absolute path to the data on their machine
+- **Type**: One of: `instagram`, `whatsapp`, `messages`, `photos`, `location`, `transactions`, `shazam`, `uber_trips`, `github`, `slack`
+
+Guide them based on page type:
+- **Person**: Typically needs messaging sources (instagram, whatsapp, messages). Photos are a bonus.
+- **Episode**: Typically needs photos, location history, and messages. Transactions and transport data add richness.
+- **Project**: Typically needs a git repository and communication data (slack, messages).
+
+### 4. Design the checkpoint sequence
+
+Based on the page type and available sources, design the checkpoint sequence. Use the examples in `evals/fixtures/examples/` as templates.
+
+**Standard checkpoint patterns by page type:**
+
+**Person:**
+1. `survey` — Snapshot first source, create source page
+2. `draft` — Write initial person page from first source (skipReference: true)
+3. `new-source` — Add remaining sources, revise page
+4. `episodes` — Create episode sub-pages for rich events
+5. `owner-input` — Integrate owner testimony (if anecdotes provided)
+6. `verify` — Final review + citation manifest
+
+**Episode:**
+1. `survey` — Snapshot photos/location, create source pages
+2. `draft` — Write day-by-day itinerary from spatial data (skipReference: true)
+3. `new-source` — Add messages/transactions, weave into narrative
+4. `persons` — Create person stubs for trip participants
+5. `owner-input` — Integrate owner memories (if anecdotes provided)
+6. `verify` — Final review + citation manifest
+
+**Project:**
+1. `survey` — Snapshot git repo, create source page
+2. `draft` — Write project page from code/commits (skipReference: true)
+3. `new-source` — Add Slack/messages, integrate collaboration context
+4. `episodes` — Create episode pages for key development moments
+5. `verify` — Final review + citation manifest
+
+For each checkpoint, set appropriate `grade` targets using the subject name and roles. Set `threshold: 0.3` on the survey checkpoint.
+
+### 5. Ask about owner anecdotes
+
+Ask:
+
+> Do you have personal memories or corrections about this subject that you'd like the agent to incorporate? These are things the digital sources can't capture — personal stories, context, corrections to what the data shows.
+
+If yes, collect entries interactively. For each entry ask:
+- What's the memory or correction?
+- What topic does it relate to?
+- Does it contradict anything in the digital sources?
+
+Write these to `owner-anecdotes.json` in the fixture directory.
+
+### 6. Ask about reference pages
+
+Ask:
+
+> Do you want to write gold-standard reference pages for grading? These are optional — they let the reference grader compare the agent's output against an ideal version.
+>
+> You can:
+> 1. **Skip for now** — the other graders (completeness, citations, editorial) still work without references
+> 2. **Write them later** — run the eval once, review the agent's output, then refine it into a reference
+> 3. **Write them now** — I'll help you draft reference pages following the editorial guide
+
+If they want to write references now, help them draft wikitext pages following the editorial guide conventions. Save to the `references/` subdirectory and add entries to the `references` map in `case.json`.
+
+### 7. Generate the fixture
+
+Determine the next available case number by listing existing directories in `evals/fixtures/<suite>/`:
+
+```bash
+ls evals/fixtures/<suite>/
+```
+
+Use the next sequential number with zero-padding (e.g., `004-person`, `005-trip`).
+
+Create the fixture directory and write all files:
+
+```
+evals/fixtures/<suite>/<NNN-type>/
+├── case.json
+├── owner-anecdotes.json    (if anecdotes were provided)
+└── references/
+    ├── <subject>.wiki      (if reference pages were written)
+    └── talk-<subject>.wiki (if talk reference was written)
+```
+
+### 8. Validate
+
+After writing the files:
+
+1. Read back the `case.json` and verify it parses correctly
+2. Check that all source paths referenced in `case.json` exist on the user's machine
+3. Check that all files referenced in `references` and `ownerInput` exist in the fixture directory
+4. Confirm the fixture follows the TypeScript types in `evals/src/types.ts`
+
+### 9. Summary
+
+Print a summary:
+
+```
+Created fixture: evals/fixtures/<suite>/<case-id>/
+  Page type: Person
+  Subject: Sarah Kim
+  Sources: instagram, whatsapp
+  Checkpoints: survey → draft → new-source → episodes → owner-input → verify
+  References: yes/no
+  Owner anecdotes: 4 entries
+
+Run it with:
+  cd evals && pnpm eval --suite <suite> --case <case-id> --harness claude-code
+```
+
+## Important notes
+
+- Source paths must be **absolute paths** on the user's machine
+- Fixture directories under `fixtures/incremental/` are gitignored — personal data stays local
+- The `snapshotId` field in sources starts empty and is populated at runtime by `wai snapshot`
+- Reference file paths in `case.json` are relative to the fixture directory
+- Use `slug-case` for reference filenames (e.g., `alex-chen.wiki`, `talk-alex-chen.wiki`)

--- a/evals/.env.example
+++ b/evals/.env.example
@@ -1,0 +1,5 @@
+# OpenAI API key — used by agents for Whisper audio transcription
+OPENAI_API_KEY=
+
+# Google Places API key — used by agents for reverse geocoding
+GOOGLE_PLACES_API_KEY=

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,0 +1,9 @@
+results/
+node_modules/
+dist/
+.env
+
+# Real fixtures contain personal data — keep them local
+fixtures/incremental/
+# Example fixtures are safe to commit
+!fixtures/examples/

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,341 @@
+# evals
+
+Evaluation toolkit for whoami.wiki editorial agents. Measures how well an AI agent can read personal archives (chat logs, photos, location history, transactions) and produce encyclopedic wiki pages following the [editorial guide](https://whoami.wiki/docs/editorial-guide).
+
+## Quick start
+
+```bash
+cd evals
+pnpm install
+```
+
+### Prerequisites
+
+The e2e runner spins up an isolated MediaWiki instance using the desktop app's bundled resources. Build them first:
+
+```bash
+cd ../desktop
+./scripts/build-php.sh
+./scripts/bundle-mediawiki.sh
+./scripts/bundle-lua.sh
+```
+
+You also need at least one fixture. Real fixtures are gitignored — create your own with `/create-fixture` in Claude Code or copy from `fixtures/examples/`.
+
+## Running an eval
+
+### End-to-end run
+
+The `run` command provisions a fresh wiki, invokes the agent harness, and grades the output:
+
+```bash
+# Run all cases in a suite
+pnpm run run --suite incremental --harness claude-code
+
+# Run a specific case
+pnpm run run --suite incremental --case 001-person --harness claude-code
+
+# Specify a model
+pnpm run run --suite incremental --case 001-person --harness claude-code --model claude-opus-4-6
+```
+
+Each run gets a clean wiki — no cross-contamination between runs.
+
+#### Run flags
+
+| Flag | Description |
+|------|-------------|
+| `--suite <name>` | **Required.** Suite to run (directory name under `fixtures/`). |
+| `--harness <name>` | **Required.** Agent harness: `claude-code`, `codex`, or `opencode`. |
+| `--case <id>` | Run only this case (matches `id` field in `case.json`). |
+| `--model <name>` | Model to use (passed to the harness). |
+| `--external-wiki` | Use your running whoami.wiki instance instead of spinning up an isolated one. Uses existing `wai` credentials. |
+| `--inspect` | Pause after grading so you can browse the wiki before teardown. |
+| `--checkpoint-threshold <n>` | Override the per-checkpoint gate score (default: from `case.json` or `0.7`). |
+| `--from-result <path>` | Resume from a previous result JSON — restores all passing checkpoints and skips them. Useful for iterating on later checkpoints without re-running expensive early ones. |
+
+#### What happens during a run
+
+For incremental suite fixtures (the primary workflow):
+
+1. **For each checkpoint** in the fixture's `checkpoints` array:
+   - The agent receives the checkpoint description as a task prompt
+   - New sources (if any) are introduced for the agent to snapshot
+   - The agent reads/creates/updates wiki pages using `wai` commands
+   - Target pages are discovered and graded against the configured graders
+   - If the score falls below the checkpoint's `threshold`, the run stops early
+2. **Results** are written to `results/<case-id>-<harness>-<timestamp>.json`
+3. **The wiki is torn down** (unless `--inspect` is set)
+
+#### Resuming from a previous run
+
+The `--from-result` flag lets you skip checkpoints that already passed:
+
+```bash
+# First run — might take 30+ minutes for all 6 checkpoints
+pnpm run run --suite incremental --case 001-person --harness claude-code
+
+# Resume from checkpoint 4 onward (reuses pages from checkpoints 1-3)
+pnpm run run --suite incremental --case 001-person --harness claude-code \
+  --from-result results/001-person-claude-code-2026-03-19T10-30-00-000Z.json
+```
+
+The runner restores all wiki pages from passing checkpoints, re-snapshots sources into the vault, and picks up where it left off.
+
+### Grading existing output
+
+The `grade` command scores wikitext without running an agent:
+
+```bash
+# Grade a single page
+pnpm run grade fixtures/incremental/001-person --page output.wikitext
+
+# Grade a directory of pages (person.wikitext, talk.wikitext, etc.)
+pnpm run grade fixtures/incremental/001-person --pages output/
+
+# Re-grade a previous result with all graders
+pnpm run grade fixtures/incremental/001-person --result results/001-person-claude-code-2026-03-19.json
+
+# Re-grade only specific graders (merges with existing scores)
+pnpm run grade fixtures/incremental/001-person --result results/001-person-claude-code-2026-03-19.json --graders accuracy,editorial
+
+# Rule-based graders only (no API key needed)
+pnpm run grade fixtures/incremental/001-person --page output.wikitext --rule-based-only
+
+# With vault path for citation verification
+pnpm run grade fixtures/incremental/001-person --page output.wikitext --vault-path ~/.whoami/vault
+```
+
+#### Grade flags
+
+| Flag | Description |
+|------|-------------|
+| `--page <file>` | Path to a single `.wikitext` file to grade. |
+| `--pages <dir>` | Path to a directory of `.wikitext` files (classified by filename: `person.wikitext`, `talk.wikitext`, `source-*.wikitext`, etc.). |
+| `--result <file>` | Path to a previous result JSON to re-grade. |
+| `--graders <list>` | Comma-separated grader names to run (merges with existing scores from `--result`). |
+| `--rule-based-only` | Skip LLM-assisted graders (completeness and citations only). No API key needed. |
+| `--vault-path <path>` | Path to the vault for citation-based accuracy verification. |
+
+### Comparing harnesses
+
+Run the same fixture with different harnesses, then generate a comparison report:
+
+```bash
+pnpm run run --suite incremental --harness claude-code --model claude-opus-4-6
+pnpm run run --suite incremental --harness codex --model gpt-5.3
+pnpm run run --suite incremental --harness opencode --model claude-opus-4-6
+
+pnpm run report results/
+```
+
+The report aggregates scores by harness/model/suite into a markdown table.
+
+### Output
+
+Results are written to `results/` as JSON files named `<case-id>-<harness>-<timestamp>.json`. Each result contains:
+
+- Per-checkpoint scores and pass/fail status
+- Per-page wikitext and grader breakdown
+- Composite score (weighted average across pages)
+- Wall-clock duration
+- Agent session transcript
+
+The console output shows a score progression chart for incremental runs:
+
+```
+  Score progression:
+     1. survey      [######..............] 0.300  2m15s
+     2. draft       [##########..........] 0.512  8m42s
+     3. new-source  [#############.......] 0.671  12m8s
+     4. episodes    [###############.....] 0.745  6m33s
+     5. owner-input [################....] 0.812  4m17s
+     6. verify      [##################..] 0.891  3m45s
+```
+
+## Wiki isolation
+
+The e2e runner reuses the desktop app's bundled resources (`desktop/resources/`):
+
+- PHP 8.3 built-in server
+- MediaWiki 1.43 with SQLite
+- Extensions: Cite, CiteThisPage, ParserFunctions, Scribunto, TemplateData, TemplateStyles, TimedMediaHandler
+- Custom namespaces: Source (100), Task (102)
+- Templates: Gap, Dialogue, Infobox person
+- Vector skin
+
+Each run creates a temp directory with its own SQLite database, generates a `LocalSettings.php` matching the desktop config, imports templates, starts PHP's built-in server on a random port, and tears everything down in `finally`. No state leaks between runs.
+
+Use `--external-wiki` to skip isolation and run against your live whoami.wiki instance instead (uses your existing `wai` credentials).
+
+## Graders
+
+Six graders score each page output on a 0–1 scale:
+
+| Grader | Type | What it checks |
+|---|---|---|
+| **Completeness** | Rule-based | Lead paragraph, infobox, body sections, references, bibliography, categories |
+| **Citations** | Rule-based | Template validity, required fields, uncited factual claims |
+| **Editorial** | Rule-based | Encyclopedic tone, third-person voice, no raw data dumps |
+| **Reference** | Rule-based | Similarity to gold-standard reference pages (section headings, infobox fields, categories) |
+| **Accuracy** | LLM-assisted | Factual claims verified against source data via citation manifest; fabrications penalized 2x |
+| **Cross-referencing** | LLM-assisted | Facts combining 2+ source types |
+
+The composite score per page is the arithmetic mean of all non-skipped graders. The overall composite weights pages by role (configurable via `weights` in `case.json`).
+
+## Fixtures
+
+Fixtures define what an agent should produce and how to score it. Each fixture lives in its own directory under `fixtures/<suite>/<case-id>/`.
+
+**Real fixtures are gitignored** because they contain personal archive data. See `fixtures/examples/` for the format, or use `/create-fixture` in Claude Code to generate one interactively.
+
+### Fixture structure
+
+```
+001-person/
+├── case.json              # Test case definition (required)
+├── owner-anecdotes.json   # Owner testimony for the owner-input checkpoint (optional)
+└── references/            # Gold-standard reference pages for grading (optional)
+    ├── subject-name.wiki
+    └── talk-subject-name.wiki
+```
+
+### case.json schema
+
+The main fixture file defines the eval case, its data sources, and the checkpoint sequence.
+
+```jsonc
+{
+  "id": "001-person",              // Unique case identifier
+  "suite": "incremental",          // Suite name (matches parent directory)
+  "description": "Write a ...",    // Human-readable task description
+  "pageType": "Person",            // "Person", "Episode", or "Project"
+  "subject": "Alex Chen",          // Primary subject name
+
+  // Data sources — absolute paths on your machine
+  "sources": [
+    { "path": "/path/to/archive/instagram", "type": "instagram", "snapshotId": "" }
+  ],
+
+  // Map page titles to reference wikitext files (relative to fixture dir)
+  // Supports globs: "Source:Instagram/*" matches any Instagram source page
+  "references": {
+    "Alex Chen": "references/alex-chen.wiki",
+    "Talk:Alex Chen": "references/talk-alex-chen.wiki"
+  },
+
+  // Optional: override default content weights for composite scoring
+  "weights": {
+    "primary": 0.85,   // Main content page weight
+    "episodes": 0,      // Episode sub-page weight
+    "talk": 0.15,       // Talk page weight
+    "source": 0.2       // Source page fraction of overall composite
+  },
+
+  // Ordered checkpoint sequence
+  "checkpoints": [
+    {
+      "id": "survey",                    // Checkpoint identifier
+      "description": "Task for agent...",  // Instructions given to the agent
+      "sources": [{ ... }],              // Sources to introduce at this step
+      "grade": [                         // Pages to grade after this step
+        { "pattern": "Source:*", "role": "source" }
+      ],
+      "threshold": 0.3,                  // Min score to proceed (optional)
+      "skipReference": false,            // Skip reference grader (optional)
+      "ownerInput": "owner-anecdotes.json", // Owner testimony file (optional)
+      "produceManifest": true            // Expect citation manifest (optional)
+    }
+  ]
+}
+```
+
+### owner-anecdotes.json
+
+First-person testimony from the wiki owner, loaded at checkpoints that specify `"ownerInput"`.
+
+```jsonc
+{
+  "speaker": "owner",
+  "context": "Wiki owner providing personal memories about Alex Chen",
+  "entries": [
+    {
+      "type": "anecdote",           // "anecdote", "context", or "correction"
+      "content": "The story...",
+      "topic": "First dinner",
+      "conflicts_with": "..."       // Optional: notes source contradictions
+    }
+  ]
+}
+```
+
+### Source types
+
+| Type | Description | Typical tools |
+|------|-------------|---------------|
+| `instagram` | Instagram data export (JSON + media) | `jq` |
+| `whatsapp` | WhatsApp chat export (SQLite) | `sqlite3` |
+| `messages` | iMessage/SMS export | `sqlite3` |
+| `photos` | Photo directory with EXIF data | `exiftool`, `jq` |
+| `location` | Location history JSON | `jq` |
+| `transactions` | Transaction CSV | `csvtool`, `awk` |
+| `shazam` | Shazam history | `jq` |
+| `uber_trips` | Uber/Lyft trip CSV | `csvtool` |
+| `github` | Git repository | `git log`, `git diff` |
+| `slack` | Slack workspace export | `jq` |
+
+### Grade target roles
+
+| Role | Graders applied | Description |
+|------|----------------|-------------|
+| `person` | completeness, citations, editorial, reference, cross-ref | Main person biography |
+| `episode` | completeness, citations, editorial, reference, cross-ref | Event/trip narrative |
+| `project` | completeness, citations, editorial, reference, cross-ref | Software project page |
+| `talk` | completeness, editorial, reference | Editorial discussion page |
+| `source` | completeness, reference | Data source documentation |
+
+### Creating fixtures
+
+Use the Claude Code skill to create fixtures interactively:
+
+```
+/create-fixture
+/create-fixture person
+/create-fixture episode
+```
+
+Or copy and modify the examples in `fixtures/examples/`.
+
+## Project structure
+
+```
+src/
+  index.ts              CLI entry point (grade | run | report)
+  types.ts              Shared interfaces
+  llm.ts                Anthropic SDK wrapper for LLM-assisted graders
+  wiki.ts               Isolated MediaWiki instance lifecycle
+  graders/              Five grader implementations + registry
+  runner/
+    grade.ts            Grade a wikitext file against a fixture
+    e2e.ts              End-to-end: provision wiki + agent + grade
+  harnesses/            Agent harness integrations (claude-code, codex, opencode)
+  reporter.ts           Markdown/JSON result aggregation
+fixtures/
+  examples/             Example fixtures with synthetic data (committed)
+  incremental/          Real fixtures with personal data (gitignored)
+test/                   Unit tests for rule-based graders
+results/                Grading output (gitignored)
+```
+
+## Tests
+
+```bash
+pnpm tsx --test test/*.test.ts
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | For LLM graders | API key for accuracy, structure, and cross-ref graders |
+| `WIKI_PORT` | No | Port for eval wiki (default: `8081`) |

--- a/evals/fixtures/examples/person/case.json
+++ b/evals/fixtures/examples/person/case.json
@@ -1,0 +1,86 @@
+{
+  "id": "001-person",
+  "suite": "incremental",
+  "description": "Write a Person page for Alex Chen using incremental editorial workflow",
+  "pageType": "Person",
+  "subject": "Alex Chen",
+  "sources": [
+    {
+      "path": "/path/to/your/archive/instagram",
+      "type": "instagram",
+      "snapshotId": ""
+    },
+    {
+      "path": "/path/to/your/archive/whatsapp",
+      "type": "whatsapp",
+      "snapshotId": ""
+    }
+  ],
+  "references": {
+    "Alex Chen": "references/alex-chen.wiki",
+    "Talk:Alex Chen": "references/talk-alex-chen.wiki"
+  },
+  "checkpoints": [
+    {
+      "id": "survey",
+      "description": "Snapshot the Instagram source directory and create an enriched source page. Catalog media files (photos, voice notes), transcribe voice notes, assess data quality (gaps, encrypted content, missing exports). Plan your editorial approach for the person page.\n\nThe source page should go beyond raw statistics — include platform limitations, querying instructions (SQL recipes, key tables), top conversations, and a critical assessment of what this source can and cannot tell us.",
+      "sources": [
+        {
+          "path": "/path/to/your/archive/instagram",
+          "type": "instagram",
+          "snapshotId": ""
+        }
+      ],
+      "grade": [{ "pattern": "Source:Instagram/*", "role": "source" }],
+      "threshold": 0.3
+    },
+    {
+      "id": "draft",
+      "description": "Write the person page for Alex Chen using only the Instagram data available so far. Include an infobox, lead paragraph, and organized sections with prose, citations, and embedded media.\n\nOn the Talk page, note episode candidates you've identified (events rich enough for their own pages) and gaps where additional sources would help.",
+      "skipReference": true,
+      "grade": [
+        { "pattern": "Alex Chen", "role": "person" },
+        { "pattern": "Talk:Alex Chen", "role": "talk" }
+      ]
+    },
+    {
+      "id": "new-source",
+      "description": "Snapshot the WhatsApp source directory and create an enriched source page for it.\n\nThen revise the person page — weave the new WhatsApp data into the existing article. Do not simply append a 'WhatsApp data' section; integrate new facts into appropriate existing sections, update the infobox with newly available fields, and remove hedging where WhatsApp data confirms what Instagram only hinted at.\n\nCross-reference facts that appear in both sources. Update the Talk page with new findings and resolved gaps.",
+      "sources": [
+        {
+          "path": "/path/to/your/archive/whatsapp",
+          "type": "whatsapp",
+          "snapshotId": ""
+        }
+      ],
+      "grade": [
+        { "pattern": "Source:Whatsapp/*", "role": "source" },
+        { "pattern": "Alex Chen", "role": "person" },
+        { "pattern": "Talk:Alex Chen", "role": "talk" }
+      ]
+    },
+    {
+      "id": "episodes",
+      "description": "Create episode pages for rich narratives discovered during research — events like first meetings, trips, conflicts, or milestones that have enough detail for their own page.\n\nLink each episode from the person page with a one-sentence summary. Each episode page should have its own infobox, citations, and embedded media where available.",
+      "grade": [{ "pattern": "Alex Chen", "role": "person" }]
+    },
+    {
+      "id": "owner-input",
+      "description": "The wiki owner has provided personal memories and corrections about Alex Chen. Integrate this testimony into the person page.\n\nCite owner statements using {{Cite testimony|speaker=...|date=...}}. Where the owner's account conflicts with digital source data, note the discrepancy on the Talk page — do not silently overwrite either version.\n\nUpdate the infobox and prose with any new biographical details from the testimony.",
+      "ownerInput": "owner-anecdotes.json",
+      "grade": [
+        { "pattern": "Alex Chen", "role": "person" },
+        { "pattern": "Talk:Alex Chen", "role": "talk" }
+      ]
+    },
+    {
+      "id": "verify",
+      "description": "Final editorial review. Audit the person page for tone, balance, and gaps. Ensure all factual claims have citations, the narrative flows coherently, and no section feels underdeveloped.\n\nProduce a citation manifest pairing every factual claim with its source evidence. Write the manifest to `./citation-manifest.json`.\n\nThe JSON format:\n```json\n{\n  \"page\": \"Alex Chen\",\n  \"claims\": [\n    {\n      \"claim\": \"Alex attended State University\",\n      \"type\": \"fact\",\n      \"citation\": \"{{Cite testimony|speaker=owner|date=2026-02-27}}\",\n      \"evidence\": \"Owner testimony: Alex went to State University\"\n    }\n  ]\n}\n```\n\nFor each claim:\n1. Read the cited source (use `sqlite3` for WhatsApp, `jq` for Instagram JSON, or note testimony)\n2. Extract the specific text that supports the claim\n3. If a claim has no supporting evidence, mark evidence as null\n\nInclude ALL factual claims from the person page, talk page, and any episode pages.",
+      "produceManifest": true,
+      "grade": [
+        { "pattern": "Alex Chen", "role": "person" },
+        { "pattern": "Talk:Alex Chen", "role": "talk" }
+      ]
+    }
+  ]
+}

--- a/evals/fixtures/examples/person/owner-anecdotes.json
+++ b/evals/fixtures/examples/person/owner-anecdotes.json
@@ -1,0 +1,27 @@
+{
+  "speaker": "owner",
+  "context": "Wiki owner providing personal memories about Alex Chen",
+  "entries": [
+    {
+      "type": "anecdote",
+      "content": "We got lost trying to find the restaurant and ended up walking through a park. Alex spotted a stray cat and spent ten minutes trying to befriend it while I looked up directions.",
+      "topic": "First dinner"
+    },
+    {
+      "type": "anecdote",
+      "content": "At the concert, someone in the row behind us kept singing off-key and Alex couldn't stop laughing. We had to move seats twice.",
+      "topic": "Concert night"
+    },
+    {
+      "type": "context",
+      "content": "Alex's roommate Sam and our mutual friend Jordan were also at the concert.",
+      "topic": "Concert night — who was there"
+    },
+    {
+      "type": "correction",
+      "content": "The messages say we met on a Thursday but it was actually a Friday — I remember because I had just finished my last class of the week.",
+      "topic": "First meeting date",
+      "conflicts_with": "Instagram DM timestamp for 2024-03-14"
+    }
+  ]
+}

--- a/evals/fixtures/examples/person/references/alex-chen.wiki
+++ b/evals/fixtures/examples/person/references/alex-chen.wiki
@@ -1,0 +1,76 @@
+{{Infobox Person
+| name = Alex Chen
+| birth_date = 15 June (year unknown, likely 1998–2000)
+| birth_place = Portland, Oregon
+| home_town = Eastside, Portland
+| education = BA Graphic Design, State University; exchange semester in Tokyo
+| occupation = Freelance illustrator, part-time barista
+| relatives = Mother (architect), younger brother "Ethan"
+| zodiac = Gemini
+| sources = Instagram, WhatsApp
+}}
+
+'''Alex Chen''' is a freelance illustrator and graphic design graduate documented in the personal archive through Instagram DMs and WhatsApp messages spanning November 2023 to April 2024. Born and raised in Portland, Oregon, Alex studied graphic design at State University before pursuing freelance illustration. The wiki owner connected with Alex through a mutual interest in indie music and Japanese art, building a friendship that evolved through an intensive six-month messaging period.
+
+[[File:Alex_Chen_profile.jpg|thumb|right|250px|Alex Chen, January 2024.]]
+
+== Background ==
+
+Alex grew up in the Eastside neighbourhood of Portland in a household that valued creative expression. Their mother is an architect who encouraged drawing from an early age, and their younger brother Ethan is studying computer science. The family keeps two cats, Miso and Tofu, who feature frequently in Alex's Instagram stories.
+
+=== Education ===
+
+Alex attended Lincoln High School before enrolling at State University, completing a BA in Graphic Design in 2022. During junior year, Alex spent an exchange semester in Tokyo at Musashino Art University, an experience that profoundly shaped their illustration style.
+
+{{Blockquote|Tokyo broke my brain in the best way. I went in drawing like every other American design student and came back obsessed with negative space and mono no aware.|Alex Chen, 18 November 2023}}
+
+=== Career ===
+
+After graduating, Alex began freelancing as an illustrator while working part-time at a specialty coffee shop. Clients include indie bands needing album art and small publishers commissioning book covers. Alex also runs a modest print shop selling risograph prints of original illustrations.
+
+== Connection with wiki owner ==
+
+The wiki owner connected with Alex through Instagram in November 2023 after discovering their illustration work through a mutual friend's story share.
+
+=== Phase 1: Art exchange ===
+
+Contact was initiated on 3 November 2023 with a message complimenting a recent illustration post.<ref name="ig-2023-11-03">{{Cite message|snapshot=a1b2c3d4|date=2023-11-03|thread=alex_thread|note=Opening message}}</ref> Alex responded with enthusiasm and the conversation quickly moved to sharing references and influences.
+
+=== Phase 2: Music bonding ===
+
+The friendship deepened around 15 November when they discovered a shared love of Japanese Breakfast and Mitski.<ref name="ig-2023-11-15">{{Cite message|snapshot=a1b2c3d4|date=2023-11-15|thread=alex_thread|note=Music discovery}}</ref> A collaborative playlist was created and became a recurring touchpoint in the conversation.
+
+=== Phase 3: Meeting in person ===
+
+Three in-person meetings occurred in January 2024: a dinner at a ramen shop on the 12th, a gallery opening on the 18th, and a concert on the 25th.<ref name="ig-2024-01-12">{{Cite message|snapshot=a1b2c3d4|date=2024-01-12|thread=alex_thread|note=First meeting}}</ref><ref name="ig-2024-01-25">{{Cite message|snapshot=a1b2c3d4|date=2024-01-25|thread=alex_thread|note=Concert}}</ref>
+
+== Interests ==
+
+=== Illustration ===
+
+Alex's illustration style blends flat colour fields with intricate line work, drawing influence from both ukiyo-e woodblock prints and contemporary graphic novels. Recurring motifs include urban landscapes, cats, and food.
+
+=== Music ===
+
+Alex is an avid listener with eclectic taste spanning indie rock, shoegaze, and city pop. Frequently mentioned artists include Japanese Breakfast, Mitski, Tatsuro Yamashita, and Slowdive.
+
+== Conversation statistics ==
+
+{| class="wikitable"
+|-
+! Metric !! Value
+|-
+| Total messages || 4,892
+|-
+| Date range || Nov 2023 – Apr 2024
+|}
+
+== References ==
+<references />
+
+== Bibliography ==
+
+{{Cite vault|type=messages|snapshot=a1b2c3d4|timestamp=2023-11-03/2024-04-15|note=Instagram DM thread.}}
+{{Cite vault|type=messages|snapshot=e5f6a7b8|timestamp=2024-01-10/2024-03-20|note=WhatsApp messages.}}
+
+[[Category:People]]

--- a/evals/fixtures/examples/person/references/talk-alex-chen.wiki
+++ b/evals/fixtures/examples/person/references/talk-alex-chen.wiki
@@ -1,0 +1,38 @@
+== Active gaps ==
+
+{{Open}} '''Birth year''' — Alex's exact birth year is not stated in any source. Messages mention being "a couple years younger" than the wiki owner, and a birthday falls on 15 June. Cross-referencing graduation year (BA 2022) suggests 1998–2000.
+
+{{Open}} '''Father''' — No mention of Alex's father in any source. The mother and brother appear frequently but the father is never referenced. This could be a sensitive topic; do not speculate.
+
+{{Open}} '''Post-April 2024''' — The message thread ends abruptly in April 2024. No source documents what happened after — whether the friendship continued on another platform or faded.
+
+== Resolved ==
+
+{{Closed}} '''Tokyo semester''' — Initially unclear whether this was a full year or one semester. WhatsApp message from 2024-01-18 confirms: "I was only there for one semester but it felt like a lifetime."
+
+{{Closed}} '''Coffee shop name''' — Instagram bio says "barista" but never names the shop. WhatsApp message from 2024-02-03 mentions "my shift at Opal" — confirmed as Opal Coffee Roasters via context.
+
+== Editorial decisions ==
+
+{{Closed}} '''Section structure''' — Organized by topic (Background, Connection, Interests) rather than chronologically. The friendship arc within "Connection with wiki owner" follows the natural phases of the conversation.
+
+{{Closed}} '''Brother's details''' — Ethan is mentioned by name in multiple messages. Included first name only; no further biographical detail since he is not a primary subject.
+
+== Episode candidates ==
+
+{{Open}} '''Tokyo semester''' — Rich enough for its own page if photo/journal sources become available. Currently only referenced through messages.
+
+{{Open}} '''Gallery opening (January 2024)''' — Alex exhibited two prints. Multiple photos exist. Could sustain an episode page with additional context from messages around that date.
+
+== Voice note index ==
+
+{| class="wikitable"
+|-
+! Date !! Duration !! Topic !! Transcribed
+|-
+| 2023-12-01 || 1:42 || Describing a new illustration project || Yes
+|-
+| 2024-01-13 || 3:15 || Recap of first dinner meeting || Yes
+|-
+| 2024-02-14 || 0:58 || Complaining about a difficult client || Yes
+|}

--- a/evals/fixtures/examples/project/case.json
+++ b/evals/fixtures/examples/project/case.json
@@ -1,0 +1,77 @@
+{
+  "id": "001-project",
+  "suite": "incremental",
+  "description": "Write a Project page for Bookshelf using incremental editorial workflow",
+  "pageType": "Project",
+  "subject": "Bookshelf",
+  "sources": [
+    {
+      "path": "/path/to/your/archive/bookshelf-repo",
+      "type": "github",
+      "snapshotId": ""
+    },
+    {
+      "path": "/path/to/your/archive/slack",
+      "type": "slack",
+      "snapshotId": ""
+    }
+  ],
+  "references": {
+    "Bookshelf": "references/bookshelf.wiki",
+    "Talk:Bookshelf": "references/talk-bookshelf.wiki"
+  },
+  "checkpoints": [
+    {
+      "id": "survey",
+      "description": "Snapshot the GitHub repository and create an enriched source page. Explore the codebase structure, commit history, branches, contributors, and CI configuration. Assess data quality — note what the repo reveals (development timeline, technical decisions, division of labor) and what it cannot tell us (motivation, context, decisions behind the code).\n\nThe source page should go beyond a file inventory — include commit volume over time, contributor breakdown, key modules and their purposes, and querying instructions.",
+      "sources": [
+        {
+          "path": "/path/to/your/archive/bookshelf-repo",
+          "type": "github",
+          "snapshotId": ""
+        }
+      ],
+      "grade": [{ "pattern": "Source:*", "role": "source" }],
+      "threshold": 0.3
+    },
+    {
+      "id": "draft",
+      "description": "Write the project page for Bookshelf using only the GitHub repository data available so far. Include an infobox (project name, language, framework, license, dates active, repository, key contributors), lead paragraph, and organized sections covering the project's purpose, technical architecture, development history, and contributors.\n\nOn the Talk page, note episode candidates you've identified (intensive development sprints, architectural changes, feature launches) and gaps where the Slack source would help fill in collaboration context.",
+      "skipReference": true,
+      "grade": [
+        { "pattern": "Bookshelf", "role": "project" },
+        { "pattern": "Talk:Bookshelf", "role": "talk" }
+      ]
+    },
+    {
+      "id": "new-source",
+      "description": "Snapshot the Slack workspace export and create an enriched source page for it. Document channels, member roster, message volume, date range, and key discussion threads.\n\nThen revise the project page — weave Slack context into the existing article. Do not append a 'Slack discussions' section; integrate collaboration dynamics, design decisions, and team interactions into appropriate existing sections.\n\nUpdate the Talk page with new findings and resolved gaps.",
+      "sources": [
+        {
+          "path": "/path/to/your/archive/slack",
+          "type": "slack",
+          "snapshotId": ""
+        }
+      ],
+      "grade": [
+        { "pattern": "Source:*", "role": "source" },
+        { "pattern": "Bookshelf", "role": "project" },
+        { "pattern": "Talk:Bookshelf", "role": "talk" }
+      ]
+    },
+    {
+      "id": "episodes",
+      "description": "Create episode pages for key moments in the project's lifecycle — development sprints, feature launches, architectural pivots, team milestones, or notable debugging sessions.\n\nLink each episode from the project page with a one-sentence summary.",
+      "grade": [{ "pattern": "Bookshelf", "role": "project" }]
+    },
+    {
+      "id": "verify",
+      "description": "Final editorial review. Audit the project page for tone, balance, and gaps. Ensure all factual claims have citations.\n\nProduce a citation manifest pairing every factual claim with its source evidence. Write the manifest to `./citation-manifest.json`.",
+      "produceManifest": true,
+      "grade": [
+        { "pattern": "Bookshelf", "role": "project" },
+        { "pattern": "Talk:Bookshelf", "role": "talk" }
+      ]
+    }
+  ]
+}

--- a/evals/fixtures/examples/project/references/bookshelf.wiki
+++ b/evals/fixtures/examples/project/references/bookshelf.wiki
@@ -1,0 +1,87 @@
+{{Infobox Project
+| name = Bookshelf
+| language = Python
+| framework = Django
+| license = MIT
+| dates_active = January 2021 – August 2022
+| repository = github.com/example/bookshelf
+| contributors = Wiki owner, Nate, Priya
+}}
+
+'''Bookshelf''' was a web application for tracking personal reading habits, built with Django and Python between January 2021 and August 2022. The project was a collaboration between the wiki owner, Nate, and Priya, originating as a weekend hackathon idea that grew into a functional product used by roughly thirty people before development stalled.
+
+== Purpose ==
+
+Bookshelf allowed users to log books they had read, assign ratings and tags, write short reviews, and view reading statistics over time. The distinguishing feature was a recommendation engine that suggested books based on overlapping taste profiles between users rather than genre metadata. The wiki owner described the motivation as wanting "Letterboxd but for books, without the social media nonsense."<ref name="slack-pitch">{{Cite message|snapshot=a1a1a1a1|date=2021-01-15|thread=general|note=Original pitch in Slack}}</ref>
+
+== Technical architecture ==
+
+The application was built on Django 3.2 with a PostgreSQL database and a minimal frontend using Django templates and HTMX for interactivity. The recommendation engine used collaborative filtering via a cosine similarity matrix recomputed nightly by a management command.
+
+=== Key modules ===
+
+* '''catalog''' — Book model, ISBN lookup via Open Library API, cover image caching
+* '''reviews''' — User reviews, ratings (1–5 scale), tag system
+* '''recommend''' — Collaborative filtering engine, similarity matrix, nightly recompute job
+* '''api''' — REST endpoints for a planned mobile client that was never built
+
+=== Infrastructure ===
+
+The application ran on a single DigitalOcean droplet ($5/month) with nginx as a reverse proxy and gunicorn as the WSGI server. Deployments were manual via SSH until Priya set up a GitHub Actions workflow in March 2021.<ref name="commit-ci">{{Cite commit|snapshot=b2b2b2b2|hash=3f7a9e1c|date=2021-03-22|note=Add GitHub Actions CI/CD}}</ref>
+
+== Development history ==
+
+=== Hackathon origin (January 2021) ===
+
+The project began at a weekend hackathon on 15–16 January 2021. The wiki owner and Nate built the initial Django scaffold with user auth, book CRUD, and a basic search page in roughly twenty hours.<ref name="commit-init">{{Cite commit|snapshot=b2b2b2b2|hash=a1b2c3d4|date=2021-01-15|note=Initial commit}}</ref> Priya joined the following week after seeing the demo in Slack.<ref name="slack-priya">{{Cite message|snapshot=a1a1a1a1|date=2021-01-18|thread=general|note=Priya asks to join}}</ref>
+
+=== Active development (February – June 2021) ===
+
+The most productive period saw 247 commits across three contributors. Key milestones included the Open Library API integration in February, the recommendation engine in April, and the tagging system in May.<ref name="commit-recommend">{{Cite commit|snapshot=b2b2b2b2|hash=e5f6a7b8|date=2021-04-12|note=Add collaborative filtering recommendation engine}}</ref>
+
+{{Blockquote|The recommendation engine was Nate's baby. He spent two weekends reading papers about collaborative filtering and came back with this elegant cosine similarity approach that worked surprisingly well with our tiny dataset.|Wiki owner, recalling development}}
+
+=== Feature plateau (July – December 2021) ===
+
+Commit frequency dropped from forty per month to roughly ten. The team added polish features — dark mode, CSV export, email digests — but no major new functionality. Slack discussions shifted from feature planning to bug reports and minor UI complaints.<ref name="slack-plateau">{{Cite message|snapshot=a1a1a1a1|date=2021-09-03|thread=general|note=Discussion about project direction}}</ref>
+
+=== Decline and abandonment (2022) ===
+
+Nate started a new job in January 2022 and his contributions dropped to zero. Priya made sporadic commits through April. The wiki owner pushed the final commit on 14 August 2022 — a dependency update that fixed a security vulnerability in Django.<ref name="commit-last">{{Cite commit|snapshot=b2b2b2b2|hash=f9e8d7c6|date=2022-08-14|note=Bump Django to 3.2.15 (security patch)}}</ref>
+
+The project was never formally shut down; it simply stopped receiving attention. The droplet continued running until December 2022 when the wiki owner cancelled the hosting subscription.
+
+== Contributors ==
+
+* '''Wiki owner''' — Backend architecture, book catalog, deployment. 312 commits (52%).
+* '''[[Nate]]''' — Recommendation engine, API endpoints, database optimisation. 198 commits (33%).
+* '''[[Priya]]''' — CI/CD pipeline, frontend improvements, tagging system. 89 commits (15%).
+
+== Commit statistics ==
+
+{| class="wikitable"
+|-
+! Period !! Commits !! Active contributors
+|-
+| Jan–Jun 2021 || 389 || 3
+|-
+| Jul–Dec 2021 || 142 || 3
+|-
+| Jan–Aug 2022 || 68 || 2
+|-
+| '''Total''' || '''599''' || '''3'''
+|}
+
+== Legacy ==
+
+Despite its abandonment, Bookshelf influenced subsequent projects by the wiki owner. The cosine similarity approach from the recommendation engine was reused in a later playlist generator. The deployment workflow Priya built became the template for all of the wiki owner's subsequent GitHub Actions configurations. Nate occasionally referenced the project in job interviews as an example of collaborative open-source work.
+
+== References ==
+<references />
+
+== Bibliography ==
+
+{{Cite vault|type=github|snapshot=b2b2b2b2|timestamp=2021-01-15/2022-08-14|note=Git repository (599 commits, 3 contributors).}}
+{{Cite vault|type=slack|snapshot=a1a1a1a1|timestamp=2021-01-15/2022-06-30|note=Slack workspace export (3 channels, ~2400 messages).}}
+
+[[Category:Projects]]

--- a/evals/fixtures/examples/project/references/talk-bookshelf.wiki
+++ b/evals/fixtures/examples/project/references/talk-bookshelf.wiki
@@ -1,0 +1,29 @@
+== Active gaps ==
+
+{{Open}} '''Mobile client''' — The API module was built for a planned mobile client that never materialised. No Slack discussion explains why it was abandoned. Nate may have context.
+
+{{Open}} '''User count''' — The page says "roughly thirty people" but no source confirms this. The number comes from a Slack message where the wiki owner said "we have like 30 users" which may have been approximate.
+
+{{Open}} '''Hosting cost''' — Only the base droplet cost ($5/month) is documented. Database hosting, domain registration, and any other costs are unknown.
+
+== Resolved ==
+
+{{Closed}} '''License''' — Initial commits had no license file. Commit `b8c9d0e1` on 2021-02-03 added MIT license. Confirmed via git log.
+
+{{Closed}} '''Priya's join date''' — Slack message from 2021-01-18 confirms Priya asked to join after seeing the demo. First commit from Priya is dated 2021-01-22.
+
+{{Closed}} '''Final commit''' — Git log confirms the last commit was on 2022-08-14 (Django security patch), not July as initially noted in an earlier draft.
+
+== Editorial decisions ==
+
+{{Closed}} '''Contributor percentages''' — Calculated from `git shortlog -sn` output. Rounded to nearest whole percent. Noted absolute commit counts alongside percentages for transparency.
+
+{{Closed}} '''Decline framing''' — Described the project's end as "stalled" and "stopped receiving attention" rather than "failed." The project achieved its goals for its scale; it simply lost momentum when contributors moved on.
+
+{{Closed}} '''Slack quoting''' — Used direct quotes from Slack sparingly and only when they add voice or context that paraphrasing would lose. Most Slack content is summarised rather than quoted.
+
+== Episode candidates ==
+
+{{Open}} '''Hackathon weekend''' — The 15–16 January 2021 hackathon has enough commit density and Slack activity to sustain its own episode page. Twenty hours of intensive coding with real-time Slack commentary.
+
+{{Open}} '''Recommendation engine sprint''' — Nate's two-weekend deep dive into collaborative filtering (late March – early April 2021) produced the project's most distinctive feature and generated substantial Slack discussion.

--- a/evals/fixtures/examples/trip/case.json
+++ b/evals/fixtures/examples/trip/case.json
@@ -1,0 +1,112 @@
+{
+  "id": "001-trip",
+  "suite": "incremental",
+  "description": "Write an Episode page for the Portland trip",
+  "pageType": "Episode",
+  "subject": "Portland trip",
+  "sources": [
+    {
+      "path": "/path/to/your/archive/camera/portland",
+      "type": "photos",
+      "snapshotId": ""
+    },
+    {
+      "path": "/path/to/your/archive/location-history.json",
+      "type": "location",
+      "snapshotId": ""
+    },
+    {
+      "path": "/path/to/your/archive/messages",
+      "type": "messages",
+      "snapshotId": ""
+    },
+    {
+      "path": "/path/to/your/archive/transactions.csv",
+      "type": "transactions",
+      "snapshotId": ""
+    }
+  ],
+  "weights": {
+    "primary": 0.85,
+    "episodes": 0,
+    "talk": 0.15,
+    "source": 0.2
+  },
+  "references": {
+    "Portland trip": "references/portland-trip.wiki",
+    "Talk:Portland trip": "references/talk-portland-trip.wiki"
+  },
+  "checkpoints": [
+    {
+      "id": "survey",
+      "description": "Snapshot the photo directory and location history. Create enriched source pages — catalog photos (count, date range, EXIF quality), assess geolocation coverage and accuracy. Note platform limitations and data quality issues.\n\nPlan your editorial approach for the episode page.",
+      "sources": [
+        {
+          "path": "/path/to/your/archive/camera/portland",
+          "type": "photos",
+          "snapshotId": ""
+        },
+        {
+          "path": "/path/to/your/archive/location-history.json",
+          "type": "location",
+          "snapshotId": ""
+        }
+      ],
+      "grade": [{ "pattern": "Source:*", "role": "source" }],
+      "threshold": 0.3
+    },
+    {
+      "id": "draft",
+      "description": "Write the episode page for the Portland trip using photos and location history. Build a day-by-day itinerary from timestamps and GPS data. Embed key photos in the sections they relate to.\n\nOn the Talk page, note gaps where additional sources (messages, transactions) would fill in context.",
+      "skipReference": true,
+      "grade": [
+        { "pattern": "Portland trip", "role": "episode" },
+        { "pattern": "Talk:Portland trip", "role": "talk" }
+      ]
+    },
+    {
+      "id": "new-source",
+      "description": "Snapshot messages and transactions. Create enriched source pages for each.\n\nIntegrate the new data into the existing episode page — weave social context from messages and spending patterns from transactions into the existing itinerary. Do not append separate sections for each source; place facts where they belong in the narrative.\n\nCross-reference across sources (e.g., a restaurant transaction + a photo at the same location + a message about dinner plans). Update the Talk page with resolved gaps and new findings.",
+      "sources": [
+        {
+          "path": "/path/to/your/archive/messages",
+          "type": "messages",
+          "snapshotId": ""
+        },
+        {
+          "path": "/path/to/your/archive/transactions.csv",
+          "type": "transactions",
+          "snapshotId": ""
+        }
+      ],
+      "grade": [
+        { "pattern": "Source:*", "role": "source" },
+        { "pattern": "Portland trip", "role": "episode" },
+        { "pattern": "Talk:Portland trip", "role": "talk" }
+      ]
+    },
+    {
+      "id": "persons",
+      "description": "Create person stub pages for key trip participants identified in messages and photos. Each stub should have an infobox with known details and a brief description of their role in the trip.\n\nLink person stubs from the episode page. Update the episode page's People section.",
+      "grade": [{ "pattern": "Portland trip", "role": "episode" }]
+    },
+    {
+      "id": "owner-input",
+      "description": "The wiki owner has provided personal memories about the Portland trip. Integrate this testimony into the episode page.\n\nCite owner statements using {{Cite testimony|speaker=...|date=...}}. Where the owner's account conflicts with digital evidence (e.g., a different restaurant name than what the transaction shows), note the discrepancy on the Talk page.\n\nUpdate the narrative with personal context that digital sources alone couldn't capture.",
+      "ownerInput": "owner-anecdotes.json",
+      "grade": [
+        { "pattern": "Portland trip", "role": "episode" },
+        { "pattern": "Talk:Portland trip", "role": "talk" }
+      ]
+    },
+    {
+      "id": "verify",
+      "description": "Final editorial review. Audit the episode page for timeline consistency, tone, and completeness. Ensure all factual claims have citations.\n\nProduce a citation manifest pairing every factual claim with its source evidence. Write the manifest to `./citation-manifest.json`.",
+      "produceManifest": true,
+      "grade": [
+        { "pattern": "Portland trip", "role": "episode" },
+        { "pattern": "Talk:Portland trip", "role": "talk" }
+      ]
+    }
+  ]
+}

--- a/evals/fixtures/examples/trip/owner-anecdotes.json
+++ b/evals/fixtures/examples/trip/owner-anecdotes.json
@@ -1,0 +1,26 @@
+{
+  "speaker": "owner",
+  "context": "Wiki owner providing personal memories about the Portland trip",
+  "entries": [
+    {
+      "type": "anecdote",
+      "content": "At the airport I had my water bottle confiscated because I forgot to empty it before security. I was annoyed the whole flight.",
+      "topic": "Departure"
+    },
+    {
+      "type": "anecdote",
+      "content": "On the first night at the rental, there was a strange humming noise from the fridge that kept us up. We unplugged it and just ate out for every meal after that.",
+      "topic": "First night at rental"
+    },
+    {
+      "type": "anecdote",
+      "content": "I bought a hand-carved wooden bird at the Saturday market. The vendor told us the story behind the design and we ended up talking for twenty minutes.",
+      "topic": "Souvenir at Saturday Market"
+    },
+    {
+      "type": "anecdote",
+      "content": "My favourite discovery was the lavender lemonade at the food cart pod. I went back for it three times.",
+      "topic": "Lavender lemonade"
+    }
+  ]
+}

--- a/evals/fixtures/examples/trip/references/portland-trip.wiki
+++ b/evals/fixtures/examples/trip/references/portland-trip.wiki
@@ -1,0 +1,79 @@
+{{Infobox Episode
+| name = Portland trip
+| date = 14–18 July 2023
+| location = Portland, Oregon
+| participants = Wiki owner, Sam, Jordan
+| transport = Flight (outbound), rental car (return)
+| photo_count = 187
+| video_count = 12
+}}
+
+The '''Portland trip''' was a five-day visit to Portland, Oregon in July 2023 undertaken by the wiki owner, Sam, and Jordan. Originally planned as a weekend getaway, it extended to five days after the group discovered a food cart pod festival running through the following Wednesday. The trip produced 187 photos, 12 short videos, and roughly 400 messages across two group chats.
+
+[[File:Portland_bridge_sunset.jpg|thumb|right|250px|Hawthorne Bridge at sunset, 15 July 2023.]]
+
+== Planning ==
+
+The trip was proposed on 20 June 2023 in a group chat message from Sam suggesting a long weekend somewhere within driving distance.<ref name="msg-2023-06-20">{{Cite message|snapshot=f1a2b3c4|date=2023-06-20|thread=trip_group|note=Trip proposal}}</ref> Portland was chosen after Jordan vetoed Seattle on account of a prior bad experience with airport security there. Flights were booked on 25 June through a budget carrier for $138 round trip.<ref name="tx-flight">{{Cite transaction|snapshot=d5e6f7a8|date=2023-06-25|amount=138.00|vendor=Budget Air|note=Round trip flight}}</ref>
+
+== Day by day ==
+
+=== July 14 (Friday) — Arrival ===
+
+The group departed on a morning flight arriving at Portland International Airport at 11:42 AM local time.<ref name="loc-arrival">{{Cite location|snapshot=b9c0d1e2|date=2023-07-14T11:42|lat=45.5898|lon=-122.5951|note=Airport arrival}}</ref> After collecting bags they took a rideshare to the rental on Division Street. The first stop was a late lunch at a taqueria two blocks from the rental where the wiki owner ordered carnitas and Sam got a michelada.<ref name="tx-lunch">{{Cite transaction|snapshot=d5e6f7a8|date=2023-07-14|amount=47.20|vendor=Taqueria Sol|note=First lunch}}</ref>
+
+The evening was spent exploring the Hawthorne neighbourhood on foot. Jordan discovered a used bookshop and spent forty minutes inside while the others waited on a bench eating ice cream from a cart across the street.<ref name="photo-hawthorne">{{Cite photo|snapshot=f1a2b3c4|date=2023-07-14|hash=aa11bb22|note=Jordan in bookshop}}</ref>
+
+=== July 15 (Saturday) — Saturday Market ===
+
+The group walked to the Saturday Market along the waterfront, arriving shortly after opening at 10 AM.<ref name="loc-market">{{Cite location|snapshot=b9c0d1e2|date=2023-07-15T10:08|lat=45.5225|lon=-122.6700|note=Saturday Market}}</ref> The wiki owner bought a hand-carved wooden bird from a vendor who explained the design was inspired by Pacific Northwest folklore. Sam bought matching enamel pins for the group.
+
+{{Blockquote|The vendor told us each bird takes about three days to carve. He had this whole wall of them, all slightly different. I picked the one with the longest tail.|Wiki owner, 15 July 2023}}
+
+The afternoon was spent at a craft brewery where they sampled a flight of eight beers and played cards for three hours.<ref name="tx-brewery">{{Cite transaction|snapshot=d5e6f7a8|date=2023-07-15|amount=62.00|vendor=Cascade Brewing|note=Beer flight and snacks}}</ref>
+
+=== July 16 (Sunday) — Forest Park ===
+
+A morning hike through Forest Park began at the Wildwood trailhead. The group hiked roughly five miles over three hours, pausing at a creek crossing for photos.<ref name="photo-creek">{{Cite photo|snapshot=f1a2b3c4|date=2023-07-16|hash=cc33dd44|note=Creek crossing group photo}}</ref> Jordan twisted an ankle on the descent and the pace slowed considerably for the final mile.
+
+Lunch was at a food cart pod near Alberta Street. The wiki owner tried lavender lemonade for the first time and returned twice more over the next two days.<ref name="tx-lemonade">{{Cite transaction|snapshot=d5e6f7a8|date=2023-07-16|amount=6.50|vendor=Bloom Cart|note=Lavender lemonade}}</ref>
+
+=== July 17 (Monday) — Powell's and the food cart festival ===
+
+The morning was spent at a large bookshop downtown. Each person set a thirty-minute timer and a twenty-dollar budget; all three exceeded both limits.<ref name="tx-books">{{Cite transaction|snapshot=d5e6f7a8|date=2023-07-17|amount=34.80|vendor=City Books|note=Book haul}}</ref>
+
+In the afternoon the group stumbled upon a food cart festival that was running all week. This discovery prompted the decision to extend the trip through Wednesday. Jordan called their employer from the festival to request two extra days off.<ref name="msg-extend">{{Cite message|snapshot=f1a2b3c4|date=2023-07-17|thread=trip_group|note=Decision to extend trip}}</ref>
+
+=== July 18 (Tuesday) — Japanese Garden and departure ===
+
+The final full day began with a visit to the Japanese Garden in Washington Park. The group spent two hours walking the grounds in near-silence, taking photos of the stone arrangements and koi pond.<ref name="photo-garden">{{Cite photo|snapshot=f1a2b3c4|date=2023-07-18|hash=ee55ff66|note=Japanese Garden stone path}}</ref>
+
+The return journey was by rental car — Sam had found a one-way deal that was cheaper than three flight changes. The drive took six hours with one stop for gas and coffee. Jordan slept through most of it.<ref name="tx-rental">{{Cite transaction|snapshot=d5e6f7a8|date=2023-07-18|amount=89.00|vendor=Budget Rental|note=One-way car rental}}</ref>
+
+== Food ==
+
+Portland's food scene was a recurring highlight. The group ate at twelve distinct venues across five days, spending a combined $310 on meals. Standout experiences included the taqueria on arrival day, a ramen shop near the rental that they visited twice, and the lavender lemonade cart that became a daily ritual. The food cart festival on day four introduced them to a Georgian khachapuri stand that Sam declared the best thing eaten on the entire trip.
+
+== People ==
+
+Three people participated in the trip:
+
+* '''Wiki owner''' — organised logistics and drove the rental car home
+* '''[[Sam]]''' — proposed the trip, served as unofficial photographer (104 of 187 photos)
+* '''[[Jordan]]''' — navigated on foot, twisted ankle on day three, bookshop enthusiast
+
+== Impact ==
+
+The Portland trip became a frequently referenced touchpoint in subsequent group conversations. The lavender lemonade became an inside joke — any time someone suggested a drink, the others would respond with "but is it lavender lemonade." The wooden bird sat on the wiki owner's desk for months afterward. Sam's photos were compiled into a shared album that accumulated 23 comments over the following week.
+
+== References ==
+<references />
+
+== Bibliography ==
+
+{{Cite vault|type=photos|snapshot=f1a2b3c4|timestamp=2023-07-14/2023-07-18|note=Trip photos (187 images, 12 videos).}}
+{{Cite vault|type=location|snapshot=b9c0d1e2|timestamp=2023-07-14/2023-07-18|note=Location history for trip duration.}}
+{{Cite vault|type=messages|snapshot=f1a2b3c4|timestamp=2023-06-20/2023-07-25|note=Group chat messages.}}
+{{Cite vault|type=transactions|snapshot=d5e6f7a8|timestamp=2023-07-14/2023-07-18|note=Transaction records.}}
+
+[[Category:Episodes]]

--- a/evals/fixtures/examples/trip/references/talk-portland-trip.wiki
+++ b/evals/fixtures/examples/trip/references/talk-portland-trip.wiki
@@ -1,0 +1,23 @@
+== Active gaps ==
+
+{{Open}} '''Day 4 evening''' — No photos or transactions between 6 PM and 10 PM on July 17. The group was at the food cart festival but no specific vendors are documented. Owner testimony may help fill this.
+
+{{Open}} '''Jordan's employer''' — Jordan called to request extra days off but the employer is never named in any source. Not critical but would add context.
+
+{{Open}} '''Return drive playlist''' — Messages reference a "road trip playlist" for the drive home but no Shazam or Spotify data covers this window.
+
+== Resolved ==
+
+{{Closed}} '''Flight cost''' — Initially unclear whether $138 was per person or total. Transaction CSV confirms it was per person ($138.00 × 3 travellers).
+
+{{Closed}} '''Saturday Market timing''' — Location history shows arrival at 10:08 AM, confirming the market had just opened (opens at 10 AM on Saturdays).
+
+{{Closed}} '''Ankle injury severity''' — Messages from the evening of July 16 confirm Jordan walked on it the next day with no issues. Minor twist, not a sprain.
+
+== Editorial decisions ==
+
+{{Closed}} '''Chronological structure''' — Organized day-by-day rather than thematically. The trip's narrative arc follows the calendar naturally and thematic sections (Food, People) supplement the timeline.
+
+{{Closed}} '''Transaction detail level''' — Included specific dollar amounts for representative purchases but did not list every transaction. The goal is colour, not an expense report.
+
+{{Closed}} '''Participant privacy''' — Used first names only for Sam and Jordan. No last names, employers, or social media handles included.

--- a/evals/package-lock.json
+++ b/evals/package-lock.json
@@ -1,0 +1,1011 @@
+{
+  "name": "@whoami-wiki/evals",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@whoami-wiki/evals",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@whoami-wiki/evals",
+  "version": "0.1.0",
+  "description": "Eval suite for whoami.wiki agent harnesses",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test test/*.test.ts",
+    "grade": "tsx src/index.ts grade",
+    "run": "tsx src/index.ts run",
+    "report": "tsx src/index.ts report"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.5.0"
+  },
+  "dependencies": {
+    "dotenv": "^17.3.1"
+  }
+}

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -1,0 +1,352 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@types/node@22.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
+  dotenv@17.3.1: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/evals/src/graders/accuracy.ts
+++ b/evals/src/graders/accuracy.ts
@@ -1,0 +1,402 @@
+import type { GraderResult } from '../types.js';
+import { extractClaims, extractClaimsOnly, validateClaimBatch } from '../llm.js';
+import { resolveCitations } from './citation-resolver.js';
+
+export interface CitationManifest {
+  page: string;
+  claims: {
+    claim: string;
+    type: string;
+    citation: string;
+    evidence: string | null;
+  }[];
+}
+
+export interface AccuracyContext {
+  vault?: { vaultPath: string };
+  sourceData?: string;
+  manifest?: CitationManifest;
+}
+
+export async function gradeAccuracy(
+  wikitext: string,
+  context: AccuracyContext,
+): Promise<GraderResult> {
+  // Manifest-based verification (agent-produced claim/evidence pairs)
+  if (context.manifest) {
+    return gradeAccuracyViaManifest(wikitext, context.manifest);
+  }
+
+  // Citation-based verification when vault is available
+  if (context.vault) {
+    return gradeAccuracyViaCitations(wikitext, context.vault.vaultPath);
+  }
+
+  // Fallback: blob-based verification
+  return gradeAccuracyViaBlob(wikitext, context.sourceData ?? '');
+}
+
+function sanitizeManifestEvidence(manifest: CitationManifest): CitationManifest {
+  return {
+    ...manifest,
+    claims: manifest.claims.map((c) => {
+      let evidence = c.evidence;
+
+      // Non-string evidence → try JSON.stringify to recover
+      if (evidence != null && typeof evidence !== 'string') {
+        try {
+          evidence = JSON.stringify(evidence);
+        } catch {
+          evidence = null;
+        }
+      }
+
+      if (typeof evidence === 'string') {
+        // Literal [object Object] or similar → null
+        if (/\[object\s+\w+\]/.test(evidence)) {
+          evidence = null;
+        // Empty or whitespace-only → null
+        } else if (evidence.trim().length === 0) {
+          evidence = null;
+        }
+      }
+
+      return { ...c, evidence };
+    }),
+  };
+}
+
+/**
+ * Strip wikitext markup for fuzzy text matching.
+ * Removes refs, bold/italic, wikilinks, templates, HTML tags, and collapses whitespace.
+ */
+function stripWikitextForMatching(text: string): string {
+  return text
+    .replace(/<ref[^>]*>[\s\S]*?<\/ref>/g, ' ')
+    .replace(/<ref[^/]*\/>/g, ' ')
+    .replace(/'{2,5}/g, '')
+    .replace(/\[\[(?:[^|\]]*\|)?([^\]]*)\]\]/g, '$1')
+    .replace(/\{\{[^}]*\}\}/g, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function gradeAccuracyViaManifest(
+  wikitext: string,
+  manifest: CitationManifest,
+): Promise<GraderResult> {
+  const sanitized = sanitizeManifestEvidence(manifest);
+
+  // Filter claims to only those relevant to the page being graded.
+  // Manifests may include claims from Talk pages or other pages — those should
+  // not penalize the episode/person page accuracy score.
+  // Claims with evidence always pass through (they get validated normally).
+  // Claims without evidence are checked against the stripped page text.
+  const strippedPage = stripWikitextForMatching(wikitext);
+  const claims = sanitized.claims.filter((c) => {
+    if (c.evidence != null) return true;
+    const snippet = c.claim.slice(0, 50);
+    return strippedPage.includes(snippet);
+  });
+
+  if (claims.length === 0) {
+    return {
+      grader: 'accuracy',
+      score: 0,
+      details: [{ check: 'Manifest contains no claims', passed: false, penalty: 1 }],
+    };
+  }
+
+  // Separate claims with and without evidence
+  const withEvidence = claims.filter((c) => c.evidence != null);
+  const withoutEvidence = claims.filter((c) => c.evidence == null);
+
+  const details: { check: string; passed: boolean; penalty: number; note?: string }[] = [];
+  let correct = 0;
+  let total = 0;
+
+  // Separate testimony claims from evidence-backed claims (testimony is attributed, not machine-verifiable)
+  const testimonyWithEvidence = withEvidence.filter((c) => c.citation && /Cite testimony/i.test(c.citation));
+  const verifiableWithEvidence = withEvidence.filter((c) => !(c.citation && /Cite testimony/i.test(c.citation)));
+
+  for (const claim of testimonyWithEvidence) {
+    correct += 1;
+    total += 1;
+    details.push({
+      check: claim.claim,
+      passed: true,
+      penalty: 0,
+      note: 'attributed: owner testimony (not machine-verifiable)',
+    });
+  }
+
+  // Validate claims with evidence in batches
+  const BATCH_SIZE = 15;
+  for (let i = 0; i < verifiableWithEvidence.length; i += BATCH_SIZE) {
+    const batch = verifiableWithEvidence.slice(i, i + BATCH_SIZE);
+    const pairs = batch.map((c) => ({ claim: c.claim, evidence: c.evidence! }));
+
+    try {
+      const validation = await validateClaimBatch(pairs);
+      for (const result of validation.results) {
+        const isFabricated = result.verdict === 'fabricated';
+        const isSupported = result.verdict === 'supported';
+
+        if (isFabricated) {
+          total += 2;
+        } else {
+          total += 1;
+        }
+
+        if (isSupported) {
+          correct += 1;
+        }
+
+        details.push({
+          check: result.claim,
+          passed: isSupported,
+          penalty: isFabricated ? 2 / claims.length : isSupported ? 0 : 1 / claims.length,
+          note: `${result.verdict}${result.reason ? `: ${result.reason}` : ''}`,
+        });
+      }
+    } catch (err) {
+      // If a batch fails, mark all claims in the batch as unsupported
+      for (const pair of pairs) {
+        total += 1;
+        details.push({
+          check: pair.claim,
+          passed: false,
+          penalty: 1 / claims.length,
+          note: `validation error: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+  }
+
+  // Claims without evidence: testimony-cited claims are 'attributed', others are 'unsupported'
+  for (const claim of withoutEvidence) {
+    const isTestimony = claim.citation && /Cite testimony/i.test(claim.citation);
+    if (isTestimony) {
+      // Properly cited owner testimony — not machine-verifiable but correctly attributed
+      correct += 1;
+      total += 1;
+      details.push({
+        check: claim.claim,
+        passed: true,
+        penalty: 0,
+        note: 'attributed: owner testimony (not machine-verifiable)',
+      });
+    } else {
+      total += 1;
+      details.push({
+        check: claim.claim,
+        passed: false,
+        penalty: 1 / claims.length,
+        note: 'unsupported: no evidence provided in manifest',
+      });
+    }
+  }
+
+  const score = total > 0 ? Math.max(0, correct / total) : 1.0;
+
+  return {
+    grader: 'accuracy',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}
+
+async function gradeAccuracyViaCitations(
+  wikitext: string,
+  vaultPath: string,
+): Promise<GraderResult> {
+  const resolved = resolveCitations(wikitext, vaultPath);
+
+  if (resolved.length === 0) {
+    return {
+      grader: 'accuracy',
+      score: 0,
+      details: [{ check: 'No citations found to verify', passed: false, penalty: 1 }],
+    };
+  }
+
+  const resolvedWithData = resolved.filter((r) => r.resolved && r.sourceExcerpt);
+  const unresolved = resolved.filter((r) => !r.resolved);
+
+  if (resolvedWithData.length === 0) {
+    return {
+      grader: 'accuracy',
+      score: 0,
+      details: [
+        ...unresolved.map((r) => ({
+          check: `Unresolved citation: ${r.raw.slice(0, 80)}`,
+          passed: false,
+          penalty: 1 / resolved.length,
+          note: r.error,
+        })),
+      ],
+    };
+  }
+
+  // Step 1: Extract claims from wikitext (no source data)
+  let extractedClaims: { text: string; type: string }[];
+  try {
+    const extraction = await extractClaimsOnly(wikitext);
+    extractedClaims = extraction.claims;
+  } catch (err) {
+    return {
+      grader: 'accuracy',
+      score: 0,
+      details: [{
+        check: 'Claim extraction failed',
+        passed: false,
+        penalty: 1,
+        note: err instanceof Error ? err.message : String(err),
+      }],
+    };
+  }
+
+  if (extractedClaims.length === 0) {
+    const resolutionScore = resolvedWithData.length / resolved.length;
+    return {
+      grader: 'accuracy',
+      score: Math.round(resolutionScore * 1000) / 1000,
+      details: [
+        { check: 'No factual claims extracted', passed: true, penalty: 0 },
+        ...unresolved.map((r) => ({
+          check: `Unresolved citation: ${r.raw.slice(0, 80)}`,
+          passed: false,
+          penalty: 0,
+          note: r.error,
+        })),
+      ],
+    };
+  }
+
+  // Step 2: Combine all resolved source excerpts into one evidence string
+  const seen = new Set<string>();
+  const excerpts: string[] = [];
+  for (const r of resolvedWithData) {
+    if (!seen.has(r.sourceExcerpt)) {
+      seen.add(r.sourceExcerpt);
+      excerpts.push(r.sourceExcerpt);
+    }
+  }
+  const combinedEvidence = excerpts.join('\n\n---\n\n');
+
+  // Step 3: Validate claims against combined evidence (same path as manifest)
+  const details: { check: string; passed: boolean; penalty: number; note?: string }[] = [];
+  let correct = 0;
+  let total = 0;
+
+  const BATCH_SIZE = 15;
+  for (let i = 0; i < extractedClaims.length; i += BATCH_SIZE) {
+    const batch = extractedClaims.slice(i, i + BATCH_SIZE);
+    const pairs = batch.map((c) => ({ claim: c.text, evidence: combinedEvidence }));
+
+    try {
+      const validation = await validateClaimBatch(pairs);
+      for (const result of validation.results) {
+        const isFabricated = result.verdict === 'fabricated';
+        const isSupported = result.verdict === 'supported';
+
+        if (isFabricated) {
+          total += 2;
+        } else {
+          total += 1;
+        }
+
+        if (isSupported) {
+          correct += 1;
+        }
+
+        details.push({
+          check: result.claim,
+          passed: isSupported,
+          penalty: isFabricated ? 2 / extractedClaims.length : isSupported ? 0 : 1 / extractedClaims.length,
+          note: `${result.verdict}${result.reason ? `: ${result.reason}` : ''}`,
+        });
+      }
+    } catch (err) {
+      for (const pair of pairs) {
+        total += 1;
+        details.push({
+          check: pair.claim,
+          passed: false,
+          penalty: 1 / extractedClaims.length,
+          note: `validation error: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+  }
+
+  // Add unresolved citation penalties
+  for (const r of unresolved) {
+    details.push({
+      check: `Unresolved citation: ${r.raw.slice(0, 80)}`,
+      passed: false,
+      penalty: 1 / resolved.length,
+      note: r.error,
+    });
+    total += 1;
+  }
+
+  const score = total > 0 ? Math.max(0, correct / total) : 1.0;
+
+  return {
+    grader: 'accuracy',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}
+
+async function gradeAccuracyViaBlob(
+  wikitext: string,
+  sourceData: string,
+): Promise<GraderResult> {
+  const extraction = await extractClaims(wikitext, sourceData);
+  const claims = extraction.claims;
+
+  if (claims.length === 0) {
+    return {
+      grader: 'accuracy',
+      score: 1.0,
+      details: [{ check: 'No factual claims found', passed: true, penalty: 0 }],
+    };
+  }
+
+  let correct = 0;
+  let total = 0;
+
+  const details = claims.map((claim) => {
+    const isSupported = claim.source === 'supported';
+    const isFabricated = claim.source === 'fabricated';
+
+    // Fabricated claims count as double penalties
+    if (isFabricated) {
+      total += 2;
+    } else {
+      total += 1;
+    }
+
+    if (isSupported) {
+      correct += 1;
+    }
+
+    return {
+      check: `${claim.type}: ${claim.text}`,
+      passed: isSupported,
+      penalty: isFabricated ? 2 / claims.length : isSupported ? 0 : 1 / claims.length,
+      note: claim.source,
+    };
+  });
+
+  const score = total > 0 ? Math.max(0, correct / total) : 1.0;
+
+  return {
+    grader: 'accuracy',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}

--- a/evals/src/graders/citation-resolver.ts
+++ b/evals/src/graders/citation-resolver.ts
@@ -1,0 +1,270 @@
+import { parseCitations } from './citations.js';
+import {
+  readManifest,
+  readObject,
+  findInManifest,
+  findAllInManifest,
+  extractMessagesNearDate,
+  type Manifest,
+} from '../vault.js';
+
+export interface ResolvedCitation {
+  /** The raw citation template text */
+  raw: string;
+  /** Extracted source excerpt (messages near date, or confirmation of file existence) */
+  sourceExcerpt: string;
+  /** Whether the citation was successfully resolved */
+  resolved: boolean;
+  /** Error message if resolution failed */
+  error?: string;
+  /** Grouping key for batching (e.g. "snapshot:thread") */
+  sourceKey?: string;
+}
+
+/**
+ * Cache key for thread file reads: "snapshotId:threadDir"
+ */
+type CacheKey = string;
+
+/**
+ * Resolve citations from wikitext against the vault.
+ *
+ * For message/voice note templates: find the thread directory in the manifest,
+ * read the message JSON, and filter by date.
+ *
+ * For photo/video templates: confirm the file exists in the manifest.
+ *
+ * For direct hash citations: read the object directly.
+ */
+export function resolveCitations(
+  wikitext: string,
+  vaultPath: string,
+): ResolvedCitation[] {
+  const citations = parseCitations(wikitext);
+  const results: ResolvedCitation[] = [];
+
+  // Cache: snapshotId:thread -> parsed JSON string
+  const threadCache = new Map<CacheKey, string | null>();
+
+  for (const citation of citations) {
+    const { fields, raw, template } = citation;
+
+    const snapshotId = fields['snapshot'] ?? fields['hash'];
+    const date = fields['date'];
+    const thread = fields['thread'];
+
+    // Direct hash with no snapshot — try reading object directly
+    if (fields['hash'] && !fields['snapshot']) {
+      const buf = readObject(vaultPath, fields['hash']);
+      if (buf) {
+        results.push({
+          raw,
+          sourceExcerpt: buf.toString('utf-8').slice(0, 2000),
+          resolved: true,
+          sourceKey: `hash:${fields['hash']}`,
+        });
+      } else {
+        results.push({
+          raw,
+          sourceExcerpt: '',
+          resolved: false,
+          error: `Object not found: ${fields['hash']}`,
+        });
+      }
+      continue;
+    }
+
+    if (!snapshotId) {
+      results.push({
+        raw,
+        sourceExcerpt: '',
+        resolved: false,
+        error: 'No snapshot or hash field',
+      });
+      continue;
+    }
+
+    const manifest = readManifest(vaultPath, snapshotId);
+    if (!manifest) {
+      results.push({
+        raw,
+        sourceExcerpt: '',
+        resolved: false,
+        error: `Manifest not found: ${snapshotId}`,
+      });
+      continue;
+    }
+
+    if (template === 'message' || template === 'voice note') {
+      // Use date or timestamp field
+      const dateField = date ?? fields['timestamp'];
+      const excerpt = resolveMessageCitation(
+        manifest,
+        vaultPath,
+        snapshotId,
+        thread,
+        dateField,
+        threadCache,
+      );
+
+      // If thread-based resolution fails, try as a file path in the manifest
+      if (excerpt === null && thread) {
+        const fileResult = resolveFileCitation(manifest, vaultPath, thread, threadCache, snapshotId);
+        if (fileResult) {
+          results.push({
+            raw,
+            sourceExcerpt: fileResult,
+            resolved: true,
+            sourceKey: `${snapshotId}:${thread}`,
+          });
+          continue;
+        }
+      }
+
+      results.push({
+        raw,
+        sourceExcerpt: excerpt ?? '',
+        resolved: excerpt !== null,
+        error: excerpt === null ? `Could not resolve message for thread=${thread}, date=${dateField}` : undefined,
+        sourceKey: `${snapshotId}:${thread ?? 'unknown'}`,
+      });
+    } else if (template === 'photo' || template === 'video') {
+      const mediaResolved = resolveMediaCitation(manifest, vaultPath, thread, fields['hash']);
+      results.push({
+        raw,
+        sourceExcerpt: mediaResolved ? `[${template} file confirmed in manifest]` : '',
+        resolved: mediaResolved,
+        error: mediaResolved ? undefined : `Media file not found in manifest`,
+        sourceKey: `${snapshotId}:media`,
+      });
+    } else if (template === 'vault') {
+      // Cite vault: confirm snapshot exists in manifest (bibliographic reference)
+      results.push({
+        raw,
+        sourceExcerpt: `[Vault reference confirmed: snapshot ${snapshotId}, ${manifest.files.length} files]`,
+        resolved: true,
+        sourceKey: `${snapshotId}:vault`,
+      });
+    } else {
+      // Unknown template — try best effort with hash
+      results.push({
+        raw,
+        sourceExcerpt: '',
+        resolved: false,
+        error: `Unknown citation template: ${template}`,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Resolve a citation where thread= points to a file path in the manifest
+ * (e.g. connections/followers_and_following, contacts.db/msgstore.db).
+ * Reads the file and returns a truncated excerpt.
+ */
+function resolveFileCitation(
+  manifest: Manifest,
+  vaultPath: string,
+  thread: string,
+  cache: Map<CacheKey, string | null>,
+  snapshotId: string,
+): string | null {
+  // Try exact path match and partial path match
+  const files = findAllInManifest(manifest, (p) => {
+    // Handle paths like "contacts.db/msgstore.db" — try each part
+    const parts = thread.split('/');
+    return parts.some((part) => p.endsWith(part) || p.includes(part));
+  });
+
+  if (files.length === 0) return null;
+
+  const excerpts: string[] = [];
+  for (const file of files.slice(0, 3)) {
+    const cacheKey: CacheKey = `${snapshotId}:${file.hash}`;
+    let content: string | null;
+
+    if (cache.has(cacheKey)) {
+      content = cache.get(cacheKey)!;
+    } else {
+      const buf = readObject(vaultPath, file.hash);
+      content = buf ? buf.toString('utf-8') : null;
+      cache.set(cacheKey, content);
+    }
+
+    if (content) {
+      excerpts.push(`[${file.path}]\n${content.slice(0, 2000)}`);
+    }
+  }
+
+  return excerpts.length > 0 ? excerpts.join('\n\n') : null;
+}
+
+function resolveMessageCitation(
+  manifest: Manifest,
+  vaultPath: string,
+  snapshotId: string,
+  thread: string | undefined,
+  date: string | undefined,
+  cache: Map<CacheKey, string | null>,
+): string | null {
+  if (!thread || !date) {
+    return null;
+  }
+
+  // Find message files in the thread directory
+  const threadFiles = findAllInManifest(manifest, (p) =>
+    p.includes(thread) && p.endsWith('.json'),
+  );
+
+  if (threadFiles.length === 0) {
+    return null;
+  }
+
+  // Try each message file in the thread
+  for (const file of threadFiles) {
+    const cacheKey: CacheKey = `${snapshotId}:${file.hash}`;
+    let json: string | null;
+
+    if (cache.has(cacheKey)) {
+      json = cache.get(cacheKey)!;
+    } else {
+      const buf = readObject(vaultPath, file.hash);
+      json = buf ? buf.toString('utf-8') : null;
+      cache.set(cacheKey, json);
+    }
+
+    if (!json) continue;
+
+    const excerpt = extractMessagesNearDate(json, date);
+    if (excerpt) {
+      return excerpt;
+    }
+  }
+
+  return null;
+}
+
+function resolveMediaCitation(
+  manifest: Manifest,
+  vaultPath: string,
+  thread: string | undefined,
+  hash: string | undefined,
+): boolean {
+  // If we have a direct hash, check if the object exists
+  if (hash) {
+    const buf = readObject(vaultPath, hash);
+    return buf !== null;
+  }
+
+  // Otherwise check if there are media files in the thread
+  if (thread) {
+    const mediaFile = findInManifest(manifest, (p) =>
+      p.includes(thread) && /\.(jpg|jpeg|png|mp4|webm|ogg|mp3)$/i.test(p),
+    );
+    return mediaFile !== undefined;
+  }
+
+  return false;
+}

--- a/evals/src/graders/citations.ts
+++ b/evals/src/graders/citations.ts
@@ -1,0 +1,193 @@
+import type { GraderResult, GraderCheck } from '../types.js';
+
+const VALID_TEMPLATES = ['message', 'voice note', 'photo', 'video', 'vault', 'testimony'];
+const REQUIRED_FIELDS = ['hash', 'date'];
+const TYPE_SPECIFIC_FIELDS: Record<string, string[]> = {
+  message: [],
+  'voice note': ['speaker'],
+  photo: [],
+  video: [],
+  vault: ['type'],
+  testimony: ['speaker'],
+};
+
+interface ParsedCitation {
+  template: string;
+  fields: Record<string, string>;
+  raw: string;
+}
+
+export function parseCitations(wikitext: string): ParsedCitation[] {
+  const citations: ParsedCitation[] = [];
+  const citeRegex = /\{\{Cite\s+([\w\s]+?)\s*\|([^}]*)\}\}/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = citeRegex.exec(wikitext)) !== null) {
+    const template = match[1].trim().toLowerCase();
+    const fieldsStr = match[2];
+    const fields: Record<string, string> = {};
+
+    for (const part of fieldsStr.split('|')) {
+      const eqIdx = part.indexOf('=');
+      if (eqIdx !== -1) {
+        const key = part.slice(0, eqIdx).trim();
+        const value = part.slice(eqIdx + 1).trim();
+        fields[key] = value;
+      }
+    }
+
+    citations.push({ template, fields, raw: match[0] });
+  }
+
+  return citations;
+}
+
+function validateCitation(citation: ParsedCitation): GraderCheck[] {
+  const checks: GraderCheck[] = [];
+
+  const validTemplate = VALID_TEMPLATES.includes(citation.template);
+  checks.push({
+    check: `Template "${citation.template}" is valid`,
+    passed: validTemplate,
+    penalty: validTemplate ? 0 : 1,
+    note: validTemplate ? undefined : `Unknown template: ${citation.template}`,
+  });
+
+  if (!validTemplate) return checks;
+
+  for (const field of REQUIRED_FIELDS) {
+    // Accept either hash or snapshot as the identifier
+    // Testimony citations have no snapshot — skip hash/snapshot requirement
+    if (field === 'hash') {
+      if (citation.template === 'testimony') {
+        // Testimony has no digital snapshot — skip
+        continue;
+      }
+      const hasId = 'hash' in citation.fields || 'snapshot' in citation.fields;
+      checks.push({
+        check: `Has hash or snapshot field`,
+        passed: hasId,
+        penalty: hasId ? 0 : 1,
+      });
+    } else if (field === 'date') {
+      // Accept either date or timestamp (vault uses timestamp)
+      const hasDate = 'date' in citation.fields || 'timestamp' in citation.fields;
+      checks.push({
+        check: `Has date or timestamp field`,
+        passed: hasDate,
+        penalty: hasDate ? 0 : 1,
+      });
+    } else {
+      const hasField = field in citation.fields;
+      checks.push({
+        check: `Has required field: ${field}`,
+        passed: hasField,
+        penalty: hasField ? 0 : 1,
+      });
+    }
+  }
+
+  const typeFields = TYPE_SPECIFIC_FIELDS[citation.template] ?? [];
+  for (const field of typeFields) {
+    const hasField = field in citation.fields;
+    checks.push({
+      check: `Has type-specific field: ${field}`,
+      passed: hasField,
+      penalty: hasField ? 0 : 0.5,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Split wikitext into paragraphs (blocks separated by blank lines or headings).
+ * Returns each paragraph with its start offset in the original text.
+ */
+function splitParagraphs(wikitext: string): { text: string; start: number }[] {
+  const paragraphs: { text: string; start: number }[] = [];
+  const blocks = wikitext.split(/\n\s*\n|(?=^==)/m);
+  let offset = 0;
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (trimmed.length > 0) {
+      paragraphs.push({ text: trimmed, start: wikitext.indexOf(trimmed, offset) });
+    }
+    offset += block.length + 1;
+  }
+  return paragraphs;
+}
+
+export function findUncitedClaims(wikitext: string): string[] {
+  const uncited: string[] = [];
+  const paragraphs = splitParagraphs(wikitext);
+
+  for (const para of paragraphs) {
+    // Skip headings, templates, categories, tables, bibliography, file/image embeds
+    if (/^==|^\{\{|^\[\[Category:|^\{\||^\[\[(?:File|Image):/i.test(para.text)) continue;
+    if (/\{\{Cite\b|<references/.test(para.text)) continue;
+
+    // If the paragraph has any <ref> tag, all sentences in it are considered cited
+    if (/<ref/.test(para.text)) continue;
+
+    // No ref in this paragraph — check each sentence for factual claims
+    const sentences = para.text.split(/(?<=[.!?])\s+/);
+    for (const sentence of sentences) {
+      if (/<ref|<references|\{\{Cite/.test(sentence)) continue;
+
+      const hasDate = /\b\d{4}\b|\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\b/i.test(sentence);
+      const hasProperNoun = /[A-Z][a-z]{2,}/.test(sentence);
+      const isFactual = hasDate || (hasProperNoun && sentence.length > 30);
+
+      if (isFactual) {
+        uncited.push(sentence.trim().slice(0, 80));
+      }
+    }
+  }
+
+  return uncited;
+}
+
+export function gradeCitations(wikitext: string): GraderResult {
+  const citations = parseCitations(wikitext);
+  const details: GraderCheck[] = [];
+
+  if (citations.length === 0) {
+    return {
+      grader: 'citations',
+      score: 0,
+      details: [{ check: 'Has at least one citation', passed: false, penalty: 1 }],
+    };
+  }
+
+  let validCount = 0;
+  for (const citation of citations) {
+    const checks = validateCitation(citation);
+    details.push(...checks);
+    const allPassed = checks.every((c) => c.passed);
+    if (allPassed) validCount++;
+  }
+
+  const uncited = findUncitedClaims(wikitext);
+  for (const claim of uncited) {
+    details.push({
+      check: 'Uncited factual claim',
+      passed: false,
+      penalty: 0.1,
+      note: claim,
+    });
+  }
+
+  // Base score: valid citations / total citations
+  let score = validCount / citations.length;
+
+  // Penalty for uncited claims: 0.05 per uncited claim, cap at 0.3
+  const uncitedPenalty = Math.min(uncited.length * 0.05, 0.3);
+  score = Math.max(0, score - uncitedPenalty);
+
+  return {
+    grader: 'citations',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}

--- a/evals/src/graders/completeness.ts
+++ b/evals/src/graders/completeness.ts
@@ -1,0 +1,382 @@
+import type { GraderResult, GraderCheck, PageRole } from '../types.js';
+
+interface Check {
+  name: string;
+  test: (wikitext: string, opts?: CompletenessOptions) => boolean;
+  /** Weight for scoring. Higher = more impact. Default 1. */
+  weight: number;
+}
+
+export interface CompletenessOptions {
+  role?: PageRole;
+  subject?: string;
+  expectedEpisodes?: string[];
+  checkpointId?: string;
+}
+
+/**
+ * Count prose words in wikitext, excluding templates, headings, categories, and ref tags.
+ */
+function countProseWords(wikitext: string): number {
+  let text = wikitext;
+  // Strip templates, ref tags, categories, headings, HTML tags, tables
+  text = text.replace(/\{\{[^}]*\}\}/gs, '');
+  text = text.replace(/<ref[^>]*>.*?<\/ref>/gs, '');
+  text = text.replace(/<ref[^/]*\/>/g, '');
+  text = text.replace(/<references\s*\/>/g, '');
+  text = text.replace(/\[\[Category:[^\]]+\]\]/g, '');
+  text = text.replace(/^==+.*==+\s*$/gm, '');
+  text = text.replace(/<[^>]+>/g, '');
+  text = text.replace(/\{\|[\s\S]*?\|\}/g, '');
+  // Strip wikilinks but keep display text
+  text = text.replace(/\[\[(?:[^|\]]*\|)?([^\]]*)\]\]/g, '$1');
+  return text.split(/\s+/).filter((w) => w.length > 0).length;
+}
+
+/**
+ * Count level-2 section headings (== Heading ==), excluding References/Bibliography/See also.
+ */
+function countContentSections(wikitext: string): number {
+  const matches = wikitext.match(/^==\s*([^=].*?)\s*==\s*$/gm);
+  if (!matches) return 0;
+  return matches.filter((m) => !/References|Bibliography|See also/i.test(m)).length;
+}
+
+/**
+ * Count level-3 subsection headings (=== Heading ===).
+ */
+function countSubsections(wikitext: string): number {
+  const matches = wikitext.match(/^===\s*[^=].*===\s*$/gm);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Count unique <ref name="..."> tags (named citations).
+ */
+function countUniqueRefs(wikitext: string): number {
+  const named = wikitext.match(/<ref\s+name="[^"]+"/g);
+  if (!named) return 0;
+  const names = new Set(named.map((r) => r.match(/"([^"]+)"/)?.[1]).filter(Boolean));
+  return names.size;
+}
+
+// ============================================================
+// Person / Episode checks
+// ============================================================
+
+// Structural checks — necessary but low weight (boilerplate)
+const STRUCTURAL_CHECKS: Check[] = [
+  {
+    name: 'Lead paragraph before first heading',
+    weight: 1,
+    test: (wikitext) => {
+      const firstHeading = wikitext.indexOf('==');
+      if (firstHeading === -1) return false;
+      const lead = wikitext.slice(0, firstHeading).trim();
+      return lead.length > 0;
+    },
+  },
+  {
+    name: 'Infobox template with required fields',
+    weight: 2,
+    test: (wikitext) => {
+      const infoboxMatch = wikitext.match(/\{\{Infobox\b[^}]*\}\}/s);
+      if (!infoboxMatch) return false;
+      const infobox = infoboxMatch[0];
+      return infobox.includes('|') && infobox.length > 20;
+    },
+  },
+  {
+    name: 'Body section with substantive prose',
+    weight: 1,
+    test: (wikitext) => {
+      const sectionRegex = /^==\s*[^=].*==\s*$/gm;
+      let match: RegExpExecArray | null;
+      const sectionStarts: number[] = [];
+      while ((match = sectionRegex.exec(wikitext)) !== null) {
+        sectionStarts.push(match.index + match[0].length);
+      }
+      for (let i = 0; i < sectionStarts.length; i++) {
+        const start = sectionStarts[i];
+        const end = i + 1 < sectionStarts.length ? sectionStarts[i + 1] : wikitext.length;
+        const content = wikitext.slice(start, end).trim();
+        const headingBefore = wikitext.slice(Math.max(0, start - 80), start);
+        if (/References|Bibliography/i.test(headingBefore)) continue;
+        if (content.length > 50) return true;
+      }
+      return false;
+    },
+  },
+  {
+    name: 'References section with <references />',
+    weight: 0.5,
+    test: (wikitext) => /==\s*References\s*==/.test(wikitext) && /<references\s*\/>/.test(wikitext),
+  },
+  {
+    name: 'Bibliography section with {{Cite vault}}',
+    weight: 0.5,
+    test: (wikitext) => /==\s*Bibliography\s*==/.test(wikitext) && /\{\{Cite vault\b/.test(wikitext),
+  },
+  {
+    name: 'At least one category tag',
+    weight: 0.5,
+    test: (wikitext) => /\[\[Category:[^\]]+\]\]/.test(wikitext),
+  },
+];
+
+// Depth checks — high weight, hard thresholds calibrated against reference pages
+const DEPTH_CHECKS: Check[] = [
+  {
+    name: 'Prose word count >= 800',
+    weight: 3,
+    test: (wikitext) => countProseWords(wikitext) >= 800,
+  },
+  {
+    name: 'At least 5 content sections',
+    weight: 3,
+    test: (wikitext) => countContentSections(wikitext) >= 5,
+  },
+  {
+    name: 'At least 3 subsections (===)',
+    weight: 2,
+    test: (wikitext) => countSubsections(wikitext) >= 3,
+  },
+  {
+    name: 'At least 10 unique inline citations',
+    weight: 2,
+    test: (wikitext) => countUniqueRefs(wikitext) >= 10,
+  },
+];
+
+/**
+ * Return depth checks with thresholds relative to the checkpoint stage.
+ * Early checkpoints (draft) have lower thresholds since not all sources are available yet.
+ */
+function getDepthChecks(checkpointId?: string): Check[] {
+  if (!checkpointId) return DEPTH_CHECKS;
+
+  let proseMin: number;
+  let sectionsMin: number;
+  let citationsMin: number;
+
+  if (checkpointId === 'draft') {
+    proseMin = 400;
+    sectionsMin = 3;
+    citationsMin = 5;
+  } else if (checkpointId === 'new-source' || checkpointId === 'episodes' || checkpointId === 'persons' || checkpointId === 'owner-input') {
+    proseMin = 700;
+    sectionsMin = 5;
+    citationsMin = 10;
+  } else {
+    // verify, survey, or default — full thresholds
+    return DEPTH_CHECKS;
+  }
+
+  return [
+    {
+      name: `Prose word count >= ${proseMin}`,
+      weight: 3,
+      test: (wikitext: string) => countProseWords(wikitext) >= proseMin,
+    },
+    {
+      name: `At least ${sectionsMin} content sections`,
+      weight: 3,
+      test: (wikitext: string) => countContentSections(wikitext) >= sectionsMin,
+    },
+    {
+      name: 'At least 3 subsections (===)',
+      weight: 2,
+      test: (wikitext: string) => countSubsections(wikitext) >= 3,
+    },
+    {
+      name: `At least ${citationsMin} unique inline citations`,
+      weight: 2,
+      test: (wikitext: string) => countUniqueRefs(wikitext) >= citationsMin,
+    },
+  ];
+}
+
+// Content richness checks — evidence of deep engagement with sources
+const RICHNESS_CHECKS: Check[] = [
+  {
+    name: 'Has blockquotes or dialogue',
+    weight: 1.5,
+    test: (wikitext) => {
+      // Formal blockquote/dialogue templates
+      if (/\{\{Blockquote\b/.test(wikitext) || /\{\{Dialogue\b/.test(wikitext) || /<blockquote>/i.test(wikitext)) return true;
+      // Inline quoted passages (>15 chars) integrated into prose — editorial guide
+      // recommends this for short quotes, reserving {{Blockquote}} for extended passages
+      const inlineQuotes = wikitext.match(/"[^"]{15,}"/g);
+      return inlineQuotes !== null && inlineQuotes.length >= 3;
+    },
+  },
+  {
+    name: 'Has embedded media (images, audio, video)',
+    weight: 1.5,
+    test: (wikitext) => /\[\[File:/.test(wikitext) || /\{\{Audio clip\b/.test(wikitext),
+  },
+];
+
+const PERSON_EPISODE_LINK: Check = {
+  name: 'Links to episode pages',
+  weight: 0.5,
+  test: (wikitext, opts) => {
+    if (!opts?.expectedEpisodes || opts.expectedEpisodes.length === 0) return true;
+    return opts.expectedEpisodes.some((ep) => wikitext.includes(`[[${ep}`));
+  },
+};
+
+const EPISODE_PERSON_LINK: Check = {
+  name: 'Links back to person page',
+  weight: 0.5,
+  test: (wikitext, opts) => {
+    if (!opts?.subject) return true;
+    return wikitext.includes(`[[${opts.subject}`);
+  },
+};
+
+// ============================================================
+// Source checks
+// ============================================================
+
+const SOURCE_CHECKS: Check[] = [
+  {
+    name: 'Has snapshot identifier',
+    weight: 1,
+    test: (wikitext) => /snapshot\s*=\s*\S+/i.test(wikitext) || /\{\{Cite vault\b[^}]*snapshot/i.test(wikitext),
+  },
+  {
+    name: 'Has source type metadata',
+    weight: 1,
+    test: (wikitext) => {
+      if (/type\s*=\s*\S+/i.test(wikitext)) return true;
+      if (/\|\s*(facebook|whatsapp|photos|messages|transactions|voice[_ ]?notes|location)\s*[\|\}]/i.test(wikitext)) return true;
+      const lead = wikitext.slice(0, 500).toLowerCase();
+      return /\b(facebook|whatsapp|instagram|photos?|messages?|transactions?|voice\s*notes?|location|android|ios)\b/.test(lead);
+    },
+  },
+  {
+    name: 'Has file listing or content summary',
+    weight: 1,
+    test: (wikitext) => {
+      const stripped = wikitext.replace(/\{\{[^}]*\}\}/g, '').replace(/^==.*==$/gm, '').trim();
+      return stripped.length > 100;
+    },
+  },
+  {
+    name: 'Has at least one category tag',
+    weight: 0.5,
+    test: (wikitext) => /\[\[Category:[^\]]+\]\]/.test(wikitext),
+  },
+  {
+    name: 'At least 2 content sections',
+    weight: 2,
+    test: (wikitext) => countContentSections(wikitext) >= 2,
+  },
+  {
+    name: 'Substantive content (>= 500 chars beyond templates)',
+    weight: 2,
+    test: (wikitext) => {
+      const stripped = wikitext
+        .replace(/\{\{[^}]*\}\}/gs, '')
+        .replace(/^==.*==$/gm, '')
+        .replace(/\[\[Category:[^\]]+\]\]/g, '')
+        .trim();
+      return stripped.length >= 500;
+    },
+  },
+];
+
+// ============================================================
+// Talk checks
+// ============================================================
+
+const TALK_CHECKS: Check[] = [
+  {
+    name: 'Has at least one section heading',
+    weight: 1,
+    test: (wikitext) => /^==\s*[^=].*==\s*$/m.test(wikitext),
+  },
+  {
+    name: 'No lead prose before first heading',
+    weight: 1,
+    test: (wikitext) => {
+      const firstHeading = wikitext.indexOf('==');
+      if (firstHeading === -1) return false;
+      const lead = wikitext.slice(0, firstHeading).trim();
+      return lead.length === 0;
+    },
+  },
+  {
+    name: 'Has editorial decisions or rationale',
+    weight: 2,
+    test: (wikitext) =>
+      /==\s*Editorial decisions\s*==/i.test(wikitext) ||
+      /==\s*Editorial\s*==/i.test(wikitext) ||
+      /\{\{Closed\}\}/i.test(wikitext) ||
+      /\{\{Superseded\}\}/i.test(wikitext),
+  },
+  {
+    name: 'Has active gaps or open questions',
+    weight: 1.5,
+    test: (wikitext) =>
+      /\{\{Open\}\}/i.test(wikitext) ||
+      /==\s*Active gaps\s*==/i.test(wikitext) ||
+      /==\s*Open questions\s*==/i.test(wikitext),
+  },
+  {
+    name: 'Has research notes or source index',
+    weight: 1.5,
+    test: (wikitext) =>
+      /==\s*Research notes\s*==/i.test(wikitext) ||
+      /==\s*Source index\s*==/i.test(wikitext) ||
+      /==\s*Key dates\s*==/i.test(wikitext) ||
+      /==\s*Key people\s*==/i.test(wikitext) ||
+      /==\s*Sources?\s*==/i.test(wikitext),
+  },
+];
+
+// ============================================================
+// Grader
+// ============================================================
+
+function getChecks(role: PageRole, checkpointId?: string): Check[] {
+  switch (role) {
+    case 'person':
+      return [...STRUCTURAL_CHECKS, ...getDepthChecks(checkpointId), ...RICHNESS_CHECKS, PERSON_EPISODE_LINK];
+    case 'project':
+      return [...STRUCTURAL_CHECKS, ...getDepthChecks(checkpointId), ...RICHNESS_CHECKS, PERSON_EPISODE_LINK];
+    case 'episode':
+      return [...STRUCTURAL_CHECKS, ...getDepthChecks(checkpointId), ...RICHNESS_CHECKS, EPISODE_PERSON_LINK];
+    case 'source':
+      return SOURCE_CHECKS;
+    case 'talk':
+      return TALK_CHECKS;
+  }
+}
+
+export function gradeCompleteness(wikitext: string, options?: CompletenessOptions): GraderResult {
+  const role = options?.role ?? 'person';
+  const checks = getChecks(role, options?.checkpointId);
+  const totalWeight = checks.reduce((sum, c) => sum + c.weight, 0);
+
+  const details: GraderCheck[] = checks.map((check) => {
+    const passed = check.test(wikitext, options);
+    return {
+      check: check.name,
+      passed,
+      penalty: passed ? 0 : check.weight / totalWeight,
+    };
+  });
+
+  const passedWeight = checks
+    .filter((_, i) => details[i].passed)
+    .reduce((sum, c) => sum + c.weight, 0);
+  const score = totalWeight > 0 ? passedWeight / totalWeight : 0;
+
+  return {
+    grader: 'completeness',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}

--- a/evals/src/graders/cross-ref.ts
+++ b/evals/src/graders/cross-ref.ts
@@ -1,0 +1,43 @@
+import type { GraderResult, TestCase } from '../types.js';
+import { extractCrossRefs } from '../llm.js';
+
+export async function gradeCrossRef(
+  wikitext: string,
+  testCase: TestCase,
+): Promise<GraderResult> {
+  const sourceTypes = [...new Set(testCase.sources.map((s) => s.type))];
+
+  if (sourceTypes.length < 2) {
+    return {
+      grader: 'cross-ref',
+      score: 0,
+      details: [
+        {
+          check: 'Fewer than 2 source types available',
+          passed: false,
+          penalty: 1,
+          note: `Only ${sourceTypes.length} source type(s) found`,
+        },
+      ],
+    };
+  }
+
+  const extraction = await extractCrossRefs(wikitext, sourceTypes);
+  const found = extraction.crossRefs.length;
+  const possible = testCase.expectedCrossRefs ?? found;
+
+  const details = extraction.crossRefs.map((ref) => ({
+    check: `Cross-ref: ${ref.fact}`,
+    passed: true,
+    penalty: 0,
+    note: `Sources: ${ref.sourceTypes.join(', ')}`,
+  }));
+
+  const score = possible > 0 ? Math.min(1, found / possible) : 1.0;
+
+  return {
+    grader: 'cross-ref',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}

--- a/evals/src/graders/editorial.ts
+++ b/evals/src/graders/editorial.ts
@@ -1,0 +1,127 @@
+import type { GraderResult, GraderCheck } from '../types.js';
+import type { RubricEvaluation } from '../llm.js';
+import { evaluateWithRubric } from '../llm.js';
+
+const WORDS_TO_WATCH = [
+  'pivotal', 'crucial', 'vital', 'fundamental', 'instrumental', 'transformative',
+  'groundbreaking', 'indelible', 'enduring', 'profound', 'testament',
+  'vibrant', 'renowned', 'nestled', 'boasts', 'showcases', 'exemplifies',
+  'stunning', 'breathtaking', 'remarkable', 'extraordinary', 'spectacular', 'masterful',
+  'genuinely', 'truly', 'deeply', 'incredibly', 'remarkably', 'undeniable', 'unmistakable',
+  'stands as', 'serves as', 'underscores', 'highlights', 'fosters', 'garners',
+  'encompasses', 'cultivates',
+  'moreover', 'furthermore', 'notably', 'additionally',
+];
+
+const PERSON_EPISODE_RUBRIC = `
+Evaluate the wikitext page against these editorial standards:
+
+1. VOICE (deduction: -0.1 each, cap -0.4)
+   - Must use third-person voice (no "I", "we", "my", "our" as the subject's voice)
+   - No editorializing or opinion
+   - No words-to-watch: ${WORDS_TO_WATCH.join(', ')}
+   - No significance inflation ("pivotal moment", "transformative experience")
+   - No vague attributions ("some say", "it is believed", "according to many")
+
+2. PROSE (deduction: -0.1 each, cap -0.3)
+   - No "stands as"/"serves as" constructions
+   - Split sentences longer than 40 words
+   - No synonym cycling (varying terms for the same concept without reason)
+   - No formulaic transitions ("moreover", "furthermore", "notably")
+   - No section-end summary sentences that restate what was just said
+
+3. EDITORIAL (deduction: -0.15 each)
+   - Biographical structure (chronological/thematic), not analytical essays
+   - Concise lead paragraph that summarizes the page
+   - Facts presented in narrative prose, not bullet lists
+   - Quotes used selectively (not dumped in bulk)
+   - Source material synthesized into prose, not transcribed verbatim
+   - Chronological or thematic section order
+
+4. SYNTAX (deduction: -0.1 each)
+   - Correct wikitext heading syntax (== Level 2 ==, === Level 3 ===)
+   - Properly formed [[wikilinks]]
+   - Properly formed {{templates}}
+   - No broken HTML tags
+`;
+
+const TALK_RUBRIC = `
+Evaluate this talk page against these editorial standards:
+
+1. CURATION (deduction: -0.2 each, cap -0.6)
+   - No bulk data dumps (raw database rows, full JSON exports, unprocessed logs)
+   - Raw transcriptions must not exceed 50% of total content
+   - Must have a summary or index section organizing the content
+
+2. EDITORIAL_CONTENT (deduction: -0.15 each)
+   - Should document editorial decisions made (what was included/excluded and why)
+   - Should track gaps (missing information, unverified claims, open questions)
+   - Should include research notes or source index (key findings, methodology)
+
+3. STRUCTURE (deduction: -0.1 each)
+   - Must have section headings organizing content
+   - No lead prose before first heading (talk pages start with headings)
+   - Content organized by topic or workflow stage
+`;
+
+const CAPS: Record<string, number> = {
+  voice: 0.4,
+  prose: 0.3,
+  curation: 0.6,
+};
+
+const EDITORIAL_PASSES = 3;
+
+function scoreEvaluation(evaluation: RubricEvaluation): { score: number; details: GraderCheck[] } {
+  const categoryTotals = new Map<string, number>();
+  let score = 1.0;
+
+  const details = evaluation.deductions.map((d) => {
+    const cat = d.category.toLowerCase();
+    const cap = CAPS[cat];
+    let appliedPenalty = Math.max(0, d.penalty);
+
+    if (cap !== undefined) {
+      const current = categoryTotals.get(cat) ?? 0;
+      const newTotal = current + d.penalty;
+      if (newTotal > cap) {
+        appliedPenalty = Math.max(0, cap - current);
+      }
+      categoryTotals.set(cat, current + d.penalty);
+    }
+
+    score -= appliedPenalty;
+
+    return {
+      check: `${d.category}: ${d.description}`,
+      passed: false,
+      penalty: appliedPenalty,
+    };
+  });
+
+  score = Math.max(0, Math.round(score * 1000) / 1000);
+  return { score, details };
+}
+
+export async function gradeEditorial(
+  wikitext: string,
+  role: 'person' | 'episode' | 'project' | 'talk',
+): Promise<GraderResult> {
+  const rubric = role === 'talk' ? TALK_RUBRIC : PERSON_EPISODE_RUBRIC;
+
+  const results: { score: number; details: GraderCheck[] }[] = [];
+
+  for (let i = 0; i < EDITORIAL_PASSES; i++) {
+    const evaluation = await evaluateWithRubric(wikitext, rubric);
+    results.push(scoreEvaluation(evaluation));
+  }
+
+  results.sort((a, b) => a.score - b.score);
+  const median = results[Math.floor(results.length / 2)];
+
+  return {
+    grader: 'editorial',
+    score: median.score,
+    details: median.details,
+  };
+}

--- a/evals/src/graders/index.ts
+++ b/evals/src/graders/index.ts
@@ -1,0 +1,189 @@
+import type { GraderResult, TestCase, PageRole } from '../types.js';
+import { gradeCompleteness, type CompletenessOptions } from './completeness.js';
+import { gradeCitations } from './citations.js';
+import { gradeAccuracy, type CitationManifest } from './accuracy.js';
+import { gradeEditorial } from './editorial.js';
+import { gradeCrossRef } from './cross-ref.js';
+import { gradeReference } from './reference.js';
+import { gradeToolUsage } from './tool-usage.js';
+import { gradeIntegration } from './integration.js';
+import { gradeSourceCriticism } from './source-criticism.js';
+
+export interface GraderOptions {
+  /** Skip LLM-assisted graders (accuracy, structure, cross-ref) */
+  ruleBasedOnly?: boolean;
+  /** Page role — controls which checks run */
+  role?: PageRole;
+  /** Subject name for cross-link checks */
+  subject?: string;
+  /** Expected episode titles for cross-link checks */
+  expectedEpisodes?: string[];
+  /** Known-good reference wikitext to compare against */
+  referenceWikitext?: string;
+  /** Vault path for citation-based accuracy verification */
+  vault?: { vaultPath: string };
+  /** Agent session transcript for tool-usage grading */
+  log?: string;
+  /** Agent-produced citation manifest for accuracy grading */
+  manifest?: CitationManifest;
+  /** Page wikitext before this checkpoint (for integration grading) */
+  previousWikitext?: string;
+  /** Checkpoint ID for context-aware completeness thresholds */
+  checkpointId?: string;
+  /** Skip the reference grader for this checkpoint */
+  skipReference?: boolean;
+  /** Talk page wikitext for integration grading (so the judge can verify discrepancy notes) */
+  talkWikitext?: string;
+  /** Run only these graders (by name). When set, all others are skipped. */
+  graderFilter?: string[];
+}
+
+export async function runGraders(
+  wikitext: string,
+  testCase: TestCase,
+  sourceData: string,
+  options: GraderOptions = {},
+): Promise<GraderResult[]> {
+  const results: GraderResult[] = [];
+  const role = options.role ?? 'person';
+  const filter = options.graderFilter;
+  const shouldRun = (name: string) => !filter || filter.includes(name);
+
+  const completenessOpts: CompletenessOptions = {
+    role,
+    subject: options.subject ?? testCase.subject,
+    expectedEpisodes: options.expectedEpisodes ?? testCase.expectedEpisodes,
+    checkpointId: options.checkpointId,
+  };
+
+  // Completeness always runs (with role-aware checks)
+  if (shouldRun('completeness')) {
+    results.push(gradeCompleteness(wikitext, completenessOpts));
+  }
+
+  // Source pages: completeness + reference + source-criticism
+  if (role === 'source') {
+    if (shouldRun('reference') && options.referenceWikitext && !options.skipReference) {
+      results.push(gradeReference(wikitext, options.referenceWikitext, role));
+    }
+    if (shouldRun('source-criticism') && !options.ruleBasedOnly) {
+      results.push(await gradeSourceCriticism(wikitext));
+    }
+    return results;
+  }
+
+  // Talk pages: completeness + reference + editorial
+  if (role === 'talk') {
+    if (shouldRun('reference') && options.referenceWikitext && !options.skipReference) {
+      results.push(gradeReference(wikitext, options.referenceWikitext, role));
+    }
+    if (shouldRun('editorial') && !options.ruleBasedOnly) {
+      results.push(await gradeEditorial(wikitext, 'talk'));
+    }
+    return results;
+  }
+
+  // Rule-based graders for person/episode
+  if (shouldRun('citations')) {
+    results.push(gradeCitations(wikitext));
+  }
+
+  // Tool-usage grader (rule-based, needs agent log)
+  if (shouldRun('tool-usage') && options.log) {
+    results.push(gradeToolUsage(options.log));
+  }
+
+  // Reference comparison when available (skip when flagged)
+  if (shouldRun('reference') && options.referenceWikitext && !options.skipReference) {
+    results.push(gradeReference(wikitext, options.referenceWikitext, role));
+  }
+
+  if (!options.ruleBasedOnly) {
+    // LLM-assisted graders (accuracy only when manifest available — too unreliable without it)
+    if (shouldRun('accuracy') && options.manifest) {
+      results.push(await gradeAccuracy(wikitext, { vault: options.vault, sourceData, manifest: options.manifest }));
+    }
+    if (shouldRun('editorial')) {
+      results.push(await gradeEditorial(wikitext, role === 'episode' ? 'episode' : role === 'project' ? 'project' : 'person'));
+    }
+    if (shouldRun('cross-ref')) {
+      results.push(await gradeCrossRef(wikitext, testCase));
+    }
+
+    // Integration grader: only when previous wikitext available and content changed
+    if (shouldRun('integration') && options.previousWikitext && options.previousWikitext !== wikitext) {
+      results.push(await gradeIntegration(options.previousWikitext, wikitext, options.talkWikitext));
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Grader weight tiers:
+ * - Quality (reference, accuracy): 50% — measures actual content quality
+ * - Content (completeness, structure): 30% — measures page structure and depth
+ * - Mechanics (citations, cross-ref, tool-usage): 20% — measures technical correctness
+ *
+ * Within each tier, weight is split equally among present graders.
+ * If an entire tier is absent, its weight redistributes proportionally.
+ */
+const GRADER_TIERS: Record<string, 'quality' | 'content' | 'mechanics'> = {
+  reference: 'quality',
+  accuracy: 'quality',
+  completeness: 'content',
+  editorial: 'content',
+  integration: 'content',
+  'source-criticism': 'content',
+  citations: 'mechanics',
+  'cross-ref': 'mechanics',
+  'tool-usage': 'mechanics',
+};
+
+const TIER_WEIGHTS: Record<string, number> = {
+  quality: 0.5,
+  content: 0.3,
+  mechanics: 0.2,
+};
+
+export function computeComposite(results: GraderResult[]): number {
+  const scored = results.filter((r) => !r.skipped);
+  if (scored.length === 0) return 0;
+
+  // Group scored graders by tier
+  const tiers = new Map<string, GraderResult[]>();
+  for (const r of scored) {
+    const tier = GRADER_TIERS[r.grader] ?? 'mechanics';
+    const group = tiers.get(tier);
+    if (group) group.push(r);
+    else tiers.set(tier, [r]);
+  }
+
+  // Calculate total weight of present tiers for redistribution
+  let presentWeight = 0;
+  for (const [tier] of tiers) {
+    presentWeight += TIER_WEIGHTS[tier] ?? 0;
+  }
+
+  if (presentWeight === 0) return 0;
+
+  let composite = 0;
+  for (const [tier, graders] of tiers) {
+    const tierWeight = (TIER_WEIGHTS[tier] ?? 0) / presentWeight;
+    const tierAvg = graders.reduce((sum, r) => sum + r.score, 0) / graders.length;
+    composite += tierAvg * tierWeight;
+  }
+
+  return Math.round(composite * 1000) / 1000;
+}
+
+export { gradeCompleteness } from './completeness.js';
+export type { CompletenessOptions } from './completeness.js';
+export { gradeCitations, parseCitations, findUncitedClaims } from './citations.js';
+export { gradeAccuracy } from './accuracy.js';
+export { gradeEditorial } from './editorial.js';
+export { gradeCrossRef } from './cross-ref.js';
+export { gradeReference } from './reference.js';
+export { gradeToolUsage } from './tool-usage.js';
+export { gradeIntegration } from './integration.js';
+export { gradeSourceCriticism } from './source-criticism.js';

--- a/evals/src/graders/integration.ts
+++ b/evals/src/graders/integration.ts
@@ -1,0 +1,90 @@
+import type { GraderResult, GraderCheck } from '../types.js';
+import type { RubricEvaluation } from '../llm.js';
+import { evaluateWithRubric } from '../llm.js';
+
+const INTEGRATION_RUBRIC = `
+Evaluate how well the CURRENT version of this page integrates new information compared to the PREVIOUS version.
+
+You will receive both versions. If a TALK PAGE is provided, use it to check whether contradictions and editorial changes were documented there.
+
+1. STRUCTURAL_INTEGRATION (deduction: -0.15 each)
+   - New facts placed in appropriate existing sections, not dumped in "Additional information"
+   - Infobox fields updated with newly available information
+   - Earlier hedging/unknown markers removed now that data is available
+
+2. NARRATIVE_COHERENCE (deduction: -0.15 each)
+   - Page reads as one unified article after revision, not as layers
+   - No sudden style shifts between original and new content
+   - Chronological/thematic flow maintained
+
+3. CONTRADICTION_HANDLING (deduction: -0.2 each)
+   - When new data conflicts with existing content, discrepancy should be noted on the Talk page
+   - If a Talk page is provided and the discrepancy IS documented there, do NOT deduct
+   - Only deduct when a substantive change is made with no acknowledgment anywhere
+   - Minor wording tweaks (e.g. tightening prose) are not contradictions
+`;
+
+const CAPS: Record<string, number> = {
+  structural_integration: 0.6,
+  narrative_coherence: 0.4,
+};
+
+const INTEGRATION_PASSES = 2;
+
+function scoreEvaluation(evaluation: RubricEvaluation): { score: number; details: GraderCheck[] } {
+  const categoryTotals = new Map<string, number>();
+  let score = 1.0;
+
+  const details = evaluation.deductions.map((d) => {
+    const cat = d.category.toLowerCase();
+    const cap = CAPS[cat];
+    let appliedPenalty = Math.max(0, d.penalty);
+
+    if (cap !== undefined) {
+      const current = categoryTotals.get(cat) ?? 0;
+      const newTotal = current + d.penalty;
+      if (newTotal > cap) {
+        appliedPenalty = Math.max(0, cap - current);
+      }
+      categoryTotals.set(cat, current + d.penalty);
+    }
+
+    score -= appliedPenalty;
+
+    return {
+      check: `${d.category}: ${d.description}`,
+      passed: false,
+      penalty: appliedPenalty,
+    };
+  });
+
+  score = Math.max(0, Math.round(score * 1000) / 1000);
+  return { score, details };
+}
+
+export async function gradeIntegration(
+  previousWikitext: string,
+  currentWikitext: string,
+  talkWikitext?: string,
+): Promise<GraderResult> {
+  let combinedInput = `=== PREVIOUS VERSION ===\n${previousWikitext}\n\n=== CURRENT VERSION ===\n${currentWikitext}`;
+  if (talkWikitext) {
+    combinedInput += `\n\n=== TALK PAGE ===\n${talkWikitext}`;
+  }
+
+  const results: { score: number; details: GraderCheck[] }[] = [];
+
+  for (let i = 0; i < INTEGRATION_PASSES; i++) {
+    const evaluation = await evaluateWithRubric(combinedInput, INTEGRATION_RUBRIC);
+    results.push(scoreEvaluation(evaluation));
+  }
+
+  results.sort((a, b) => a.score - b.score);
+  const median = results[Math.floor(results.length / 2)];
+
+  return {
+    grader: 'integration',
+    score: median.score,
+    details: median.details,
+  };
+}

--- a/evals/src/graders/reference.ts
+++ b/evals/src/graders/reference.ts
@@ -1,0 +1,171 @@
+import type { GraderResult, GraderCheck, PageRole } from '../types.js';
+
+/**
+ * Extract == Level 2 == section headings from wikitext.
+ */
+function extractHeadings(wikitext: string): string[] {
+  const matches = wikitext.match(/^==\s*([^=].*?)\s*==\s*$/gm);
+  if (!matches) return [];
+  return matches.map((m) => m.replace(/^==\s*/, '').replace(/\s*==\s*$/, '').trim().toLowerCase());
+}
+
+/**
+ * Extract infobox fields (| key = value) from first {{Infobox ...}} template.
+ */
+function extractInfoboxFields(wikitext: string): string[] {
+  const infoboxMatch = wikitext.match(/\{\{Infobox\b[^}]*\}\}/s);
+  if (!infoboxMatch) return [];
+  const fields: string[] = [];
+  const fieldRegex = /\|\s*(\w[\w\s]*?)\s*=/g;
+  let match: RegExpExecArray | null;
+  while ((match = fieldRegex.exec(infoboxMatch[0])) !== null) {
+    fields.push(match[1].trim().toLowerCase());
+  }
+  return fields;
+}
+
+/**
+ * Extract citation hashes (hash = X or snapshot = X) from {{Cite ...}} templates.
+ */
+function extractCitationHashes(wikitext: string): string[] {
+  const hashes: string[] = [];
+  const regex = /\{\{Cite\s+\w+[^}]*\}\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(wikitext)) !== null) {
+    const hashMatch = match[0].match(/(?:hash|snapshot)\s*=\s*([^\s|}\]]+)/);
+    if (hashMatch) {
+      hashes.push(hashMatch[1].toLowerCase());
+    }
+  }
+  return hashes;
+}
+
+/**
+ * Extract [[Category:X]] tags from wikitext.
+ */
+function extractCategories(wikitext: string): string[] {
+  const matches = wikitext.match(/\[\[Category:([^\]]+)\]\]/g);
+  if (!matches) return [];
+  return matches.map((m) => {
+    const inner = m.match(/\[\[Category:([^\]]+)\]\]/);
+    return inner ? inner[1].trim().toLowerCase() : '';
+  }).filter(Boolean);
+}
+
+/**
+ * Compute fraction of reference items present in agent output.
+ */
+function coverage(referenceItems: string[], agentItems: string[]): number {
+  if (referenceItems.length === 0) return 1;
+  const agentSet = new Set(agentItems);
+  const found = referenceItems.filter((item) => agentSet.has(item)).length;
+  return found / referenceItems.length;
+}
+
+/**
+ * Grade content pages (person/episode/talk) against reference.
+ */
+function gradeContentReference(wikitext: string, referenceWikitext: string): { score: number; details: GraderCheck[] } {
+  const details: GraderCheck[] = [];
+
+  // Section heading coverage (0.4)
+  const refHeadings = extractHeadings(referenceWikitext);
+  const agentHeadings = extractHeadings(wikitext);
+  const headingCov = coverage(refHeadings, agentHeadings);
+  details.push({
+    check: 'Section heading coverage',
+    passed: headingCov >= 0.5,
+    penalty: (1 - headingCov) * 0.4,
+    note: `${Math.round(headingCov * 100)}% (${agentHeadings.filter((h) => refHeadings.map((r) => r.toLowerCase()).includes(h)).length}/${refHeadings.length})`,
+  });
+
+  // Infobox field coverage (0.2)
+  const refFields = extractInfoboxFields(referenceWikitext);
+  const agentFields = extractInfoboxFields(wikitext);
+  const fieldCov = coverage(refFields, agentFields);
+  details.push({
+    check: 'Infobox field coverage',
+    passed: fieldCov >= 0.5,
+    penalty: (1 - fieldCov) * 0.2,
+    note: `${Math.round(fieldCov * 100)}% (${agentFields.filter((f) => refFields.includes(f)).length}/${refFields.length})`,
+  });
+
+  // Citation hash presence (0.2) — checks that agent citations include hashes,
+  // not that they match reference hashes (fresh snapshots produce different hashes)
+  const refHashCount = extractCitationHashes(referenceWikitext).length;
+  const agentHashCount = extractCitationHashes(wikitext).length;
+  const hashPresence = refHashCount > 0 ? Math.min(agentHashCount / refHashCount, 1.0) : 1.0;
+  details.push({
+    check: 'Citation hash presence',
+    passed: hashPresence >= 0.5,
+    penalty: (1 - hashPresence) * 0.2,
+    note: `${Math.round(hashPresence * 100)}% (${agentHashCount}/${refHashCount} hash-bearing citations)`,
+  });
+
+  // Category coverage (0.2)
+  const refCategories = extractCategories(referenceWikitext);
+  const agentCategories = extractCategories(wikitext);
+  const catCov = coverage(refCategories, agentCategories);
+  details.push({
+    check: 'Category coverage',
+    passed: catCov >= 0.5,
+    penalty: (1 - catCov) * 0.2,
+    note: `${Math.round(catCov * 100)}% (${agentCategories.filter((c) => refCategories.includes(c)).length}/${refCategories.length})`,
+  });
+
+  const score = headingCov * 0.4 + fieldCov * 0.2 + hashPresence * 0.2 + catCov * 0.2;
+  return { score, details };
+}
+
+/**
+ * Grade source pages against reference.
+ */
+function gradeSourceReference(wikitext: string, referenceWikitext: string): { score: number; details: GraderCheck[] } {
+  const details: GraderCheck[] = [];
+
+  // Content length ratio (0.3) — capped at 1.0
+  const ratio = referenceWikitext.length > 0
+    ? Math.min(wikitext.length / referenceWikitext.length, 1.0)
+    : (wikitext.length > 0 ? 1.0 : 0);
+  details.push({
+    check: 'Content length ratio',
+    passed: ratio >= 0.5,
+    penalty: (1 - ratio) * 0.3,
+    note: `${Math.round(ratio * 100)}% (${wikitext.length}/${referenceWikitext.length} chars)`,
+  });
+
+  // Key line coverage (0.7) — fuzzy: trimmed, case-insensitive
+  const refLines = referenceWikitext
+    .split('\n')
+    .map((l) => l.trim().toLowerCase())
+    .filter((l) => l.length > 0);
+
+  const agentText = wikitext.toLowerCase();
+  const matchedLines = refLines.filter((line) => agentText.includes(line));
+  const lineCov = refLines.length > 0 ? matchedLines.length / refLines.length : 1;
+
+  details.push({
+    check: 'Key line coverage',
+    passed: lineCov >= 0.5,
+    penalty: (1 - lineCov) * 0.7,
+    note: `${Math.round(lineCov * 100)}% (${matchedLines.length}/${refLines.length} lines)`,
+  });
+
+  const score = ratio * 0.3 + lineCov * 0.7;
+  return { score, details };
+}
+
+/**
+ * Compare agent output against a known-good reference page.
+ */
+export function gradeReference(wikitext: string, referenceWikitext: string, role: PageRole): GraderResult {
+  const { score, details } = role === 'source'
+    ? gradeSourceReference(wikitext, referenceWikitext)
+    : gradeContentReference(wikitext, referenceWikitext);
+
+  return {
+    grader: 'reference',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}

--- a/evals/src/graders/source-criticism.ts
+++ b/evals/src/graders/source-criticism.ts
@@ -1,0 +1,75 @@
+import type { GraderResult, GraderCheck } from '../types.js';
+import type { RubricEvaluation } from '../llm.js';
+import { evaluateWithRubric } from '../llm.js';
+
+const SOURCE_CRITICISM_RUBRIC = `
+Evaluate whether this source page includes critical assessment beyond raw statistics.
+
+1. CRITICAL_ASSESSMENT (deduction: -0.15 each, cap -0.5)
+   - Notes platform limitations (what this source can/cannot tell us)
+   - Identifies gaps in coverage (date ranges, missing threads, deleted messages)
+   - Assesses data quality (encrypted content, media not exported)
+   - Distinguishes metadata from content
+
+2. DOCUMENTATION_QUALITY (deduction: -0.1 each)
+   - Has querying instructions (SQL recipes, key tables)
+   - Includes top conversations or content breakdown
+   - Notes date range and volume statistics
+`;
+
+const CAPS: Record<string, number> = {
+  critical_assessment: 0.5,
+};
+
+const SOURCE_CRITICISM_PASSES = 2;
+
+function scoreEvaluation(evaluation: RubricEvaluation): { score: number; details: GraderCheck[] } {
+  const categoryTotals = new Map<string, number>();
+  let score = 1.0;
+
+  const details = evaluation.deductions.map((d) => {
+    const cat = d.category.toLowerCase();
+    const cap = CAPS[cat];
+    let appliedPenalty = Math.max(0, d.penalty);
+
+    if (cap !== undefined) {
+      const current = categoryTotals.get(cat) ?? 0;
+      const newTotal = current + d.penalty;
+      if (newTotal > cap) {
+        appliedPenalty = Math.max(0, cap - current);
+      }
+      categoryTotals.set(cat, current + d.penalty);
+    }
+
+    score -= appliedPenalty;
+
+    return {
+      check: `${d.category}: ${d.description}`,
+      passed: false,
+      penalty: appliedPenalty,
+    };
+  });
+
+  score = Math.max(0, Math.round(score * 1000) / 1000);
+  return { score, details };
+}
+
+export async function gradeSourceCriticism(
+  wikitext: string,
+): Promise<GraderResult> {
+  const results: { score: number; details: GraderCheck[] }[] = [];
+
+  for (let i = 0; i < SOURCE_CRITICISM_PASSES; i++) {
+    const evaluation = await evaluateWithRubric(wikitext, SOURCE_CRITICISM_RUBRIC);
+    results.push(scoreEvaluation(evaluation));
+  }
+
+  results.sort((a, b) => a.score - b.score);
+  const median = results[Math.floor(results.length / 2)];
+
+  return {
+    grader: 'source-criticism',
+    score: median.score,
+    details: median.details,
+  };
+}

--- a/evals/src/graders/tool-usage.ts
+++ b/evals/src/graders/tool-usage.ts
@@ -1,0 +1,65 @@
+import type { GraderResult } from '../types.js';
+
+/**
+ * Grade whether the agent used the wai CLI tools properly.
+ *
+ * Checks:
+ * 1. Used wai CLI at all
+ * 2. Used wai snapshot to ingest source data
+ * 3. Used wai read to read wiki content
+ * 4. Used wai write/edit/create to author pages
+ */
+export function gradeToolUsage(log: string | undefined): GraderResult {
+  if (!log) {
+    return {
+      grader: 'tool-usage',
+      score: 0,
+      skipped: true,
+      details: [{ check: 'No agent log available', passed: false, penalty: 0 }],
+    };
+  }
+
+  const checks = [
+    {
+      name: 'Used wai CLI',
+      test: () => /\bwai\s/.test(log),
+      weight: 1,
+    },
+    {
+      name: 'Used wai snapshot for source ingestion',
+      test: () => /\bwai\s+snapshot\b/.test(log),
+      weight: 1,
+    },
+    {
+      name: 'Used wai read to inspect pages',
+      test: () => /\bwai\s+read\b/.test(log),
+      weight: 1,
+    },
+    {
+      name: 'Used wai write/edit/create to author pages',
+      test: () => /\bwai\s+(write|edit|create)\b/.test(log),
+      weight: 1,
+    },
+  ];
+
+  const totalWeight = checks.reduce((sum, c) => sum + c.weight, 0);
+  let passedWeight = 0;
+
+  const details = checks.map((check) => {
+    const passed = check.test();
+    if (passed) passedWeight += check.weight;
+    return {
+      check: check.name,
+      passed,
+      penalty: passed ? 0 : check.weight / totalWeight,
+    };
+  });
+
+  const score = totalWeight > 0 ? passedWeight / totalWeight : 0;
+
+  return {
+    grader: 'tool-usage',
+    score: Math.round(score * 1000) / 1000,
+    details,
+  };
+}

--- a/evals/src/harnesses/claude-code.ts
+++ b/evals/src/harnesses/claude-code.ts
@@ -1,0 +1,161 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import type { Harness, HarnessResult, HarnessRunOptions } from './types.js';
+import type { TestCase } from '../types.js';
+import { buildSourcePrompt, buildContentPrompt, buildCheckpointPrompt } from './prompts.js';
+
+function buildPrompt(task: TestCase, wikiUrl: string): string {
+  const sources = task.sources
+    .map((s) => `- ${s.path}`)
+    .join('\n');
+
+  return `You are writing a ${task.pageType} page for whoami.wiki.
+
+Task: ${task.description}
+
+Source directories to ingest:
+${sources}
+
+Wiki URL: ${wikiUrl}
+
+Instructions:
+1. Snapshot each source directory using \`wai snapshot <dir>\`
+2. Read the ingested source pages using \`wai source list\` and \`wai read\`
+3. Extract facts from the source data
+4. Write a well-structured wikitext page following editorial standards
+5. Include proper citations using {{Cite ...}} templates
+6. Create the page using \`wai create\` or \`wai write\`
+
+Return the final wikitext of the page you created.`;
+}
+
+export function createClaudeCodeHarness(model?: string): Harness {
+  return {
+    name: 'claude-code',
+    async run(task: TestCase, env: Record<string, string | undefined>, options?: HarnessRunOptions): Promise<HarnessResult> {
+      const wikiUrl = env['WIKI_SERVER'] ?? 'http://localhost:8081';
+
+      let prompt: string;
+      if (options?.checkpoint) {
+        prompt = buildCheckpointPrompt(task, wikiUrl, options.checkpoint, options.checkpointIndex ?? 0, options.priorPages ?? [], options.ownerInput);
+      } else {
+        switch (options?.phase) {
+          case 'source':
+            prompt = buildSourcePrompt(task, wikiUrl);
+            break;
+          case 'content':
+            prompt = buildContentPrompt(task, wikiUrl);
+            break;
+          default:
+            prompt = buildPrompt(task, wikiUrl);
+            break;
+        }
+      }
+
+      const resumeSessionId = options?.sessionId;
+      const sessionId = resumeSessionId ?? randomUUID();
+
+      const args: string[] = [];
+
+      if (resumeSessionId) {
+        // Resume existing session: --resume <id> sends the prompt as a new message
+        args.push('--resume', resumeSessionId, '-p', prompt);
+      } else {
+        // Fresh session: use --session-id so we can resume later
+        args.push('-p', prompt, '--session-id', sessionId);
+      }
+
+      args.push(
+        '--dangerously-skip-permissions',
+        '--verbose',
+        '--output-format', 'stream-json',
+      );
+
+      if (model) {
+        args.push('--model', model);
+      }
+
+      const timeoutMs = options?.timeoutMs ?? 45 * 60 * 1000; // default 45 minutes
+
+      return new Promise((resolve, reject) => {
+        // Reuse working directory when resuming so the agent can see files it created
+        const cwd = options?.cwd ?? mkdtempSync(join(tmpdir(), 'whoami-eval-harness-'));
+        const proc = spawn('claude', args, {
+          stdio: ['ignore', 'pipe', 'inherit'],
+          cwd,
+          env,
+        });
+
+        let stdout = '';
+        let resolved = false;
+        let resolvedModel: string | undefined;
+
+        const timer = setTimeout(() => {
+          if (!resolved) {
+            resolved = true;
+            proc.kill('SIGTERM');
+            setTimeout(() => proc.kill('SIGKILL'), 10_000);
+            resolve({ output: '', log: stdout + '\n[TIMEOUT] Agent killed after ' + (timeoutMs / 1000) + 's', model: resolvedModel, sessionId, cwd });
+          }
+        }, timeoutMs);
+
+        proc.stdout.on('data', (data: Buffer) => {
+          const chunk = data.toString();
+          stdout += chunk;
+
+          // Detect completion from stream-json events
+          // Each line is a JSON object; look for {"type":"result"} which signals the session is done
+          for (const line of chunk.split('\n')) {
+            if (!line.trim()) continue;
+            try {
+              const event = JSON.parse(line);
+              if (event.type === 'system' && event.model) {
+                resolvedModel = event.model;
+              }
+              if (event.type === 'result') {
+                // Session complete — resolve and kill process (it may not exit on its own)
+                if (!resolved) {
+                  resolved = true;
+                  clearTimeout(timer);
+                  resolve({ output: '', log: stdout, model: resolvedModel, sessionId, cwd });
+                  // Give it a moment to exit gracefully, then force kill
+                  setTimeout(() => {
+                    try { proc.kill('SIGTERM'); } catch { /* already dead */ }
+                    setTimeout(() => {
+                      try { proc.kill('SIGKILL'); } catch { /* already dead */ }
+                    }, 5_000);
+                  }, 2_000);
+                }
+              }
+            } catch {
+              // Not valid JSON line, skip
+            }
+          }
+        });
+
+        proc.on('close', (code) => {
+          clearTimeout(timer);
+          if (!resolved) {
+            resolved = true;
+            if (code !== 0) {
+              reject(new Error(`claude exited with code ${code}`));
+            } else {
+              resolve({ output: '', log: stdout, model: resolvedModel, sessionId, cwd });
+            }
+          }
+        });
+
+        proc.on('error', (err) => {
+          clearTimeout(timer);
+          if (!resolved) {
+            resolved = true;
+            reject(new Error(`Failed to spawn claude: ${err.message}`));
+          }
+        });
+      });
+    },
+  };
+}

--- a/evals/src/harnesses/codex.ts
+++ b/evals/src/harnesses/codex.ts
@@ -1,0 +1,145 @@
+import { spawn, execSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { Harness, HarnessResult, HarnessRunOptions } from './types.js';
+import type { TestCase } from '../types.js';
+import { buildSourcePrompt, buildContentPrompt, buildCheckpointPrompt } from './prompts.js';
+
+function buildPrompt(task: TestCase, wikiUrl: string): string {
+  const sources = task.sources
+    .map((s) => `- ${s.type}: ${s.path} (snapshot: ${s.snapshotId})`)
+    .join('\n');
+
+  return `Write a ${task.pageType} page for whoami.wiki.
+
+Task: ${task.description}
+
+Sources:
+${sources}
+
+Wiki URL: ${wikiUrl}
+
+Use the wai CLI to read sources and create the page. Follow Wikipedia-style editorial standards.`;
+}
+
+export function createCodexHarness(model?: string): Harness {
+  // Parse provider from model string: "lmstudio:model-name" or "ollama:model-name"
+  let provider: string | undefined;
+  let modelName = model;
+  if (model?.includes(':')) {
+    const [prefix, ...rest] = model.split(':');
+    if (prefix === 'lmstudio' || prefix === 'ollama') {
+      provider = prefix;
+      modelName = rest.join(':');
+    }
+  }
+
+  return {
+    name: 'codex',
+    async run(task: TestCase, env: Record<string, string | undefined>, options?: HarnessRunOptions): Promise<HarnessResult> {
+      const wikiUrl = env['WIKI_SERVER'] ?? 'http://localhost:8081';
+
+      let prompt: string;
+      if (options?.checkpoint) {
+        prompt = buildCheckpointPrompt(task, wikiUrl, options.checkpoint, options.checkpointIndex ?? 0, options.priorPages ?? [], options.ownerInput);
+      } else {
+        switch (options?.phase) {
+          case 'source':
+            prompt = buildSourcePrompt(task, wikiUrl);
+            break;
+          case 'content':
+            prompt = buildContentPrompt(task, wikiUrl);
+            break;
+          default:
+            prompt = buildPrompt(task, wikiUrl);
+            break;
+        }
+      }
+
+      const resumeSessionId = options?.sessionId;
+
+      const args: string[] = [];
+
+      if (resumeSessionId) {
+        // Resume existing session: codex exec resume <id> <prompt> --full-auto --json
+        args.push('exec', 'resume', resumeSessionId, prompt, '--full-auto', '--json');
+      } else {
+        // Fresh session: codex exec --full-auto --json <prompt>
+        args.push('exec', '--full-auto', '--json', prompt);
+      }
+
+      if (provider) {
+        args.push('--oss', '--local-provider', provider);
+      }
+      if (modelName) {
+        args.push('--model', modelName);
+      }
+
+      const timeoutMs = options?.timeoutMs ?? 45 * 60 * 1000;
+
+      return new Promise((resolve, reject) => {
+        // Reuse working directory when resuming so the agent can see files it created
+        const cwd = options?.cwd ?? mkdtempSync(join(tmpdir(), 'whoami-eval-harness-'));
+        if (!options?.cwd) {
+          execSync('git init -q', { cwd });
+        }
+        const proc = spawn('codex', args, {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          cwd,
+          env,
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let timedOut = false;
+
+        const timer = setTimeout(() => {
+          timedOut = true;
+          proc.kill('SIGTERM');
+          setTimeout(() => proc.kill('SIGKILL'), 10_000);
+        }, timeoutMs);
+
+        proc.stdout.on('data', (data: Buffer) => {
+          stdout += data.toString();
+        });
+
+        proc.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        proc.on('close', (code) => {
+          clearTimeout(timer);
+          // Extract thread_id from JSONL output for session resume
+          let sessionId: string | undefined;
+          let resolvedModel: string | undefined;
+          for (const line of stdout.split('\n')) {
+            if (!line.trim()) continue;
+            try {
+              const event = JSON.parse(line);
+              if (event.type === 'thread.started' && event.thread_id) {
+                sessionId = event.thread_id;
+              }
+            } catch {
+              // Not JSON, skip
+            }
+          }
+          resolvedModel = modelName ?? model;
+
+          if (timedOut) {
+            resolve({ output: '', log: stdout + '\n[TIMEOUT] Agent killed after ' + (timeoutMs / 1000) + 's', model: resolvedModel, sessionId, cwd });
+          } else if (code !== 0) {
+            reject(new Error(`codex exited with code ${code}: ${stderr}`));
+          } else {
+            resolve({ output: '', log: stdout, model: resolvedModel, sessionId, cwd });
+          }
+        });
+
+        proc.on('error', (err) => {
+          clearTimeout(timer);
+          reject(new Error(`Failed to spawn codex: ${err.message}`));
+        });
+      });
+    },
+  };
+}

--- a/evals/src/harnesses/opencode.ts
+++ b/evals/src/harnesses/opencode.ts
@@ -1,0 +1,238 @@
+import { spawn, execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import type { Harness, HarnessResult, HarnessRunOptions } from './types.js';
+import type { TestCase } from '../types.js';
+import { buildSourcePrompt, buildContentPrompt, buildCheckpointPrompt } from './prompts.js';
+
+function buildPrompt(task: TestCase, wikiUrl: string): string {
+  const sources = task.sources
+    .map((s) => `- ${s.type}: ${s.path} (snapshot: ${s.snapshotId})`)
+    .join('\n');
+
+  return `Write a ${task.pageType} page for whoami.wiki.
+
+Task: ${task.description}
+
+Sources:
+${sources}
+
+Wiki URL: ${wikiUrl}
+
+Use the wai CLI to read sources and create the page. Follow Wikipedia-style editorial standards.`;
+}
+
+interface ProviderConfig {
+  provider: string;   // e.g. "lmstudio", "vercel"
+  modelName: string;  // e.g. "openai/gpt-oss-20b", "moonshotai/kimi-k2.5"
+  baseURL: string;
+  apiKeyEnv?: string; // env var name for API key (e.g. "AI_GATEWAY_API_KEY")
+}
+
+const PROVIDER_DEFAULTS: Record<string, { baseURL: string; apiKeyEnv?: string }> = {
+  lmstudio: { baseURL: 'http://127.0.0.1:1234/v1' },
+  ollama: { baseURL: 'http://127.0.0.1:11434/v1' },
+  vercel: { baseURL: 'https://ai-gateway.vercel.sh/v1', apiKeyEnv: 'AI_GATEWAY_API_KEY' },
+  moonshot: { baseURL: 'https://api.moonshot.ai/v1', apiKeyEnv: 'MOONSHOT_API_KEY' },
+};
+
+function parseProvider(model: string): ProviderConfig | undefined {
+  if (!model.includes(':')) return undefined;
+  const [prefix, ...rest] = model.split(':');
+  const defaults = PROVIDER_DEFAULTS[prefix];
+  if (!defaults) return undefined;
+  return { provider: prefix, modelName: rest.join(':'), baseURL: defaults.baseURL, apiKeyEnv: defaults.apiKeyEnv };
+}
+
+function writeOpenCodeConfig(
+  cwd: string,
+  provider: ProviderConfig | undefined,
+  env: Record<string, string | undefined>,
+  allowPaths?: string[],
+): void {
+  const config: Record<string, unknown> = {
+    $schema: 'https://opencode.ai/config.json',
+  };
+
+  if (provider) {
+    const providerOptions: Record<string, unknown> = { baseURL: provider.baseURL };
+    if (provider.apiKeyEnv) {
+      const apiKey = env[provider.apiKeyEnv];
+      if (apiKey) {
+        providerOptions.headers = { Authorization: `Bearer ${apiKey}` };
+      }
+    }
+    config.provider = {
+      [provider.provider]: {
+        npm: '@ai-sdk/openai-compatible',
+        name: provider.provider,
+        options: providerOptions,
+        models: {
+          [provider.modelName]: {
+            name: provider.modelName,
+          },
+        },
+      },
+    };
+  }
+
+  // Allow access to source directories, vault, and common tool paths
+  const rules: Record<string, string> = {};
+  if (allowPaths) {
+    for (const p of allowPaths) {
+      rules[`${p}/**`] = 'allow';
+    }
+  }
+  // Allow vault path (where wai stores snapshots/objects)
+  const vaultPath = env['WAI_VAULT_PATH'];
+  if (vaultPath) {
+    rules[`${vaultPath}/**`] = 'allow';
+  }
+  // Allow wai CLI and common tool locations
+  rules['/usr/local/bin/*'] = 'allow';
+  rules[`${env['HOME'] ?? '~'}/.local/bin/*`] = 'allow';
+  // Allow tmp directories (eval working dirs)
+  rules['/tmp/**'] = 'allow';
+  rules['/private/var/folders/**'] = 'allow';
+  config.permission = { external_directory: rules };
+
+  writeFileSync(join(cwd, 'opencode.json'), JSON.stringify(config, null, 2));
+}
+
+export function createOpenCodeHarness(model?: string): Harness {
+  const customProvider = model ? parseProvider(model) : undefined;
+
+  return {
+    name: 'opencode',
+    async run(task: TestCase, env: Record<string, string | undefined>, options?: HarnessRunOptions): Promise<HarnessResult> {
+      const wikiUrl = env['WIKI_SERVER'] ?? 'http://localhost:8081';
+
+      let prompt: string;
+      if (options?.checkpoint) {
+        prompt = buildCheckpointPrompt(task, wikiUrl, options.checkpoint, options.checkpointIndex ?? 0, options.priorPages ?? [], options.ownerInput);
+      } else {
+        switch (options?.phase) {
+          case 'source':
+            prompt = buildSourcePrompt(task, wikiUrl);
+            break;
+          case 'content':
+            prompt = buildContentPrompt(task, wikiUrl);
+            break;
+          default:
+            prompt = buildPrompt(task, wikiUrl);
+            break;
+        }
+      }
+
+      const resumeSessionId = options?.sessionId;
+
+      // opencode run [flags] <message..>
+      const args = ['run'];
+
+      if (resumeSessionId) {
+        // Resume existing session: --session <id> continues the conversation
+        args.push('--session', resumeSessionId);
+      }
+
+      if (customProvider) {
+        args.push('--model', `${customProvider.provider}/${customProvider.modelName}`);
+      } else if (model) {
+        args.push('--model', model);
+      }
+
+      args.push('--format', 'json');
+      args.push(prompt);
+
+      const timeoutMs = options?.timeoutMs ?? 45 * 60 * 1000;
+
+      return new Promise((resolve, reject) => {
+        // Reuse working directory when resuming so the agent can see files it created
+        const cwd = options?.cwd ?? mkdtempSync(join(tmpdir(), 'whoami-eval-harness-'));
+
+        // Write config with provider settings and filesystem permissions
+        const sourcePaths = task.sources.map((s) => s.path);
+        writeOpenCodeConfig(cwd, customProvider, env, sourcePaths);
+
+        // Copy OpenCode extensions (AGENTS.md + skills) into the working directory
+        if (!resumeSessionId) {
+          const thisDir = dirname(fileURLToPath(import.meta.url));
+          const extensionsDir = join(thisDir, '..', '..', '..', 'extensions', 'opencode');
+          if (existsSync(extensionsDir)) {
+            const agentsMd = join(extensionsDir, 'AGENTS.md');
+            if (existsSync(agentsMd)) {
+              execSync(`cp "${agentsMd}" "${cwd}/AGENTS.md"`);
+            }
+            const skillsDir = join(extensionsDir, 'skills');
+            if (existsSync(skillsDir)) {
+              execSync(`mkdir -p "${cwd}/.opencode/skills" && cp -r "${skillsDir}/"* "${cwd}/.opencode/skills/"`);
+            }
+          }
+        }
+
+        const proc = spawn('opencode', args, {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          cwd,
+          env,
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let timedOut = false;
+
+        const timer = setTimeout(() => {
+          timedOut = true;
+          proc.kill('SIGTERM');
+          setTimeout(() => proc.kill('SIGKILL'), 10_000);
+        }, timeoutMs);
+
+        proc.stdout.on('data', (data: Buffer) => {
+          stdout += data.toString();
+        });
+
+        proc.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        proc.on('close', (code) => {
+          clearTimeout(timer);
+          let sessionId: string | undefined;
+          let resolvedModel: string | undefined;
+          for (const line of stdout.split('\n')) {
+            if (!line.trim()) continue;
+            try {
+              const obj = JSON.parse(line);
+              if (obj.sessionID && !sessionId) { sessionId = obj.sessionID; }
+              if (obj.model && !resolvedModel) { resolvedModel = obj.model; }
+            } catch { /* skip non-JSON lines */ }
+          }
+          if (!resolvedModel && customProvider) {
+            resolvedModel = `${customProvider.provider}/${customProvider.modelName}`;
+          } else if (!resolvedModel && model) {
+            resolvedModel = model;
+          }
+
+          // Detect API/billing errors in stderr (opencode exits 0 on these)
+          const billingErrorPattern = /Insufficient balance|rate_limit_exceeded|billing.*error|quota.*exceeded/i;
+          const hasBillingError = billingErrorPattern.test(stderr);
+
+          if (timedOut) {
+            resolve({ output: stdout, log: (stderr || stdout) + '\n[TIMEOUT] Agent killed after ' + (timeoutMs / 1000) + 's', model: resolvedModel, sessionId, cwd });
+          } else if (code !== 0) {
+            reject(new Error(`opencode exited with code ${code}: ${stderr}`));
+          } else if (hasBillingError) {
+            reject(new Error(`opencode hit API/billing error (exit 0): ${stderr.slice(0, 500)}`));
+          } else {
+            resolve({ output: stdout, log: stderr || stdout, model: resolvedModel, sessionId, cwd });
+          }
+        });
+
+        proc.on('error', (err) => {
+          clearTimeout(timer);
+          reject(new Error(`Failed to spawn opencode: ${err.message}`));
+        });
+      });
+    },
+  };
+}

--- a/evals/src/harnesses/prompts.ts
+++ b/evals/src/harnesses/prompts.ts
@@ -1,0 +1,204 @@
+import type { TestCase, CheckpointSpec } from '../types.js';
+
+export function buildSourcePrompt(task: TestCase, wikiUrl: string): string {
+  const sources = task.sources
+    .map((s) => `- ${s.path}`)
+    .join('\n');
+
+  return `You are developing source documentation pages for whoami.wiki.
+
+Task: Snapshot and document the following data sources.
+
+Source directories to ingest:
+${sources}
+
+Wiki URL: ${wikiUrl}
+
+Instructions:
+1. Snapshot each source directory using \`wai snapshot <dir>\`
+2. Read the generated source pages using \`wai source list\` and \`wai read\`
+3. The snapshot command creates minimal pages with only a file-type table.
+   Enrich each source page with detailed documentation:
+   - Open databases and files in the vault to extract statistics
+   - Add an overview table (account holder, platform, date range, total records)
+   - Document key files, content breakdowns, top conversations
+   - Add data quality notes and querying instructions (SQL recipes, key tables)
+   - Follow the editorial guide's source page structure
+4. Update each source page using \`wai write\``;
+}
+
+export function buildContentPrompt(task: TestCase, wikiUrl: string): string {
+  return `You are writing a ${task.pageType} page for whoami.wiki — a personal encyclopedia documenting a person's life through primary sources (chat logs, social media exports, databases).
+
+Task: ${task.description}
+
+Wiki URL: ${wikiUrl}
+
+## Research strategy
+
+Your goal is to write a rich, encyclopedic article about a person — not a data analysis report. The page should read like a Wikipedia biography grounded in primary sources.
+
+### Phase 1: Understand the data landscape
+1. Run \`wai source list\` and \`wai read\` on each source page
+2. Study the **Top conversations** table to find relevant threads
+3. Note the **Querying** section — it shows how to resolve snapshot hashes to vault objects
+
+### Phase 2: Deep-read conversations for biographical facts
+This is the most important phase. You need to read actual message content, not just aggregate statistics.
+
+- **Sample broadly across the timeline**: Don't just read the first/last N messages. Use the monthly volume table to identify high-activity periods, then sample 50-100 messages from each.
+- **Search for biographical keywords**: Query messages containing words like "born", "birthday", "school", "college", "work", "job", "moved", "family", "sister", "brother", "mom", "dad", "home" to find identity-revealing passages.
+- **Read key narrative moments**: First contact, first meeting, confessions, conflicts, reunions, farewells — these are the backbone of a person page.
+- **Cross-reference sources**: If a person appears in both Instagram and WhatsApp, compare what's said in each to build a fuller picture.
+- **Extract direct quotes**: Find memorable or revealing statements that can be used as blockquotes. These bring the page to life.
+
+### Phase 3: Write the page
+- **Infobox first**: Fill in as many fields as the data supports (name, birth_date, birth_place, home_town, education, occupation, relatives, etc.)
+- **Lead paragraph**: Identify the person, their relationship to the wiki owner, and the arc of their connection — in documentary voice, not data-report voice.
+- **Sections**: Organize by topic (Background, Education, Work/Interests, Connection with [wiki owner], etc.), not by data source. Aim for 5+ sections with subsections.
+- **Density**: Target 800+ words of prose. Include blockquotes, direct quotes, and specific details (dates, places, names).
+- **Citations**: Every factual claim needs a \`{{Cite message}}\` with snapshot, date, and thread fields. Use \`{{Cite vault}}\` in the Bibliography.
+- **Talk page**: Post open editorial gaps (unverified claims, missing data) as separate threads with \`{{Open}}\` tags.
+
+### Common mistakes to avoid
+- Writing a "thread analysis" or "message profile" instead of a biography
+- Only extracting aggregate stats (message counts, date ranges) without reading what was actually said
+- Sampling only from the edges of a conversation (first/last messages) instead of the biographical middle
+- Leaving infobox fields empty when the data is available in messages
+- Omitting blockquotes and dialogue — these are expected in person pages
+
+## Tools
+- \`wai source list\` / \`wai read "<title>"\` — read wiki pages
+- \`wai create "<title>"\` / \`wai write "<title>" <file>\` — create/update pages
+- \`wai talk create "<title>" -s "<subject>" -c "<content>"\` — post to talk page
+- Use \`jq\` and \`sqlite3\` to query vault objects per the source page instructions`;
+}
+
+interface OwnerAnecdote {
+  type: string;
+  content: string;
+  topic?: string;
+  conflicts_with?: string;
+}
+
+export function buildCheckpointPrompt(
+  task: TestCase,
+  wikiUrl: string,
+  checkpoint: CheckpointSpec,
+  checkpointIndex: number,
+  priorPages: string[],
+  ownerEntries?: unknown[],
+): string {
+  const parts: string[] = [];
+
+  // Context
+  parts.push(`You are working on a ${task.pageType} page for whoami.wiki — a personal encyclopedia documenting a person's life through primary sources.`);
+  parts.push('');
+  parts.push(`Wiki URL: ${wikiUrl}`);
+  parts.push('');
+
+  // Step header
+  parts.push(`## Step ${checkpointIndex + 1}: ${checkpoint.id}`);
+  parts.push('');
+  parts.push(checkpoint.description);
+  parts.push('');
+
+  // New sources for this checkpoint
+  if (checkpoint.sources && checkpoint.sources.length > 0) {
+    parts.push('### New sources to ingest');
+    for (const s of checkpoint.sources) {
+      parts.push(`- ${s.path}`);
+    }
+    parts.push('');
+    parts.push('Snapshot each new source directory using `wai snapshot <dir>`, then read the generated source pages with `wai source list` and `wai read`.');
+    parts.push('');
+  }
+
+  // Existing pages from prior checkpoints
+  if (priorPages.length > 0) {
+    parts.push('### Existing wiki pages');
+    parts.push('The following pages already exist in the wiki from previous steps. Read them with `wai read "<title>"` to understand what has been done so far:');
+    for (const title of priorPages) {
+      parts.push(`- "${title}"`);
+    }
+    parts.push('');
+  }
+
+  // Expected output from grade targets
+  const gradePatterns = checkpoint.grade.map((g) => `${g.pattern} (${g.role})`);
+  if (gradePatterns.length > 0) {
+    parts.push('### Expected output');
+    parts.push('After this step, the following pages should exist or be updated:');
+    for (const p of gradePatterns) {
+      parts.push(`- ${p}`);
+    }
+    parts.push('');
+  }
+
+  // Planning guidance at checkpoint 1
+  if (checkpointIndex === 0) {
+    parts.push('### Editorial planning');
+    parts.push('Plan your editorial approach before diving into the data. Use whatever planning tools are available to organize the work — outline the key questions to answer, the sections you expect to write, and the research strategy for finding biographical facts in the source data.');
+    parts.push('');
+  }
+
+  // Owner-provided context
+  if (ownerEntries && ownerEntries.length > 0) {
+    parts.push('### Owner-provided context');
+    parts.push('The wiki owner has shared personal memories and corrections.');
+    parts.push('Cite these using `{{Cite testimony|speaker=...|date=...}}`.');
+    parts.push('Where they conflict with digital source data, note the discrepancy on the Talk page.');
+    parts.push('');
+    for (const entry of ownerEntries as OwnerAnecdote[]) {
+      const label = entry.type ? `[${entry.type}]` : '';
+      const topic = entry.topic ? ` (${entry.topic})` : '';
+      const conflict = entry.conflicts_with ? ` ⚠️ Conflicts with: ${entry.conflicts_with}` : '';
+      parts.push(`- ${label}${topic} ${entry.content}${conflict}`);
+    }
+    parts.push('');
+  }
+
+  // Media embedding guidance
+  const mediaStages = ['survey', 'draft', 'new-source', 'episodes', 'persons', 'owner-input', 'verify'];
+  if (mediaStages.includes(checkpoint.id)) {
+    parts.push('### Media embedding');
+    parts.push('When you upload a file with `wai upload`, it becomes available at `[[File:filename.ext]]`. Embed uploaded files in the wikitext where they enrich the reader\'s understanding — don\'t embed everything, only files that add meaningful context to a section.');
+    parts.push('');
+    parts.push('**Prefer individual files over contact sheets.** Upload each meaningful photo separately and embed it in the specific section it relates to — e.g. a concert photo in the Music section, a travel photo in the trip subsection. Use `[[File:name.jpg|thumb|caption]]` inline or `| image = name.jpg` in the infobox. Contact sheets are useful as a supplementary overview on source pages, but the main content pages should use individual images placed in context.');
+    parts.push('');
+    parts.push('For audio: use `[[File:name.ogg]]` or `[[File:name.mp3]]` inline near the relevant text.');
+    parts.push('');
+
+    parts.push('Previously uploaded files are available as `[[File:...]]`. Check what files exist with `wai read "Special:ListFiles"` or look at source pages, and embed any that are relevant to the sections you are writing. Prefer placing individual photos in context rather than linking to contact sheets.');
+    parts.push('');
+  }
+
+  // Timezone guidance
+  parts.push('### Timezone handling');
+  parts.push('Source data often uses mixed timezone representations. Before citing any timestamp:');
+  parts.push('- **Uber/Lyft CSVs**: Check the timezone column (e.g. `America/New_York`). The `_local` columns may still be in UTC despite the name.');
+  parts.push('- **iMessage/SMS exports**: Timestamps display in the recording device\'s timezone, which may differ from the location at the time.');
+  parts.push('- **EXIF photo metadata**: Check `Offset Time` or `Time Zone Offset` fields for the UTC offset (e.g. `-06:00` for CST).');
+  parts.push('- **Location history JSON**: Check for explicit UTC offsets in timestamp fields (e.g. `2022-03-26T14:00:00-06:00`).');
+  parts.push('- **General rule**: Convert all timestamps to the local timezone of the event location before writing them in the article. Note the source timezone in citations when ambiguous.');
+  parts.push('');
+
+  // Tools reference
+  parts.push('### Tools');
+  parts.push('- `wai source list` / `wai read "<title>"` — read wiki pages');
+  parts.push('- `wai snapshot <dir>` — snapshot a source directory into the vault');
+  parts.push('- `wai create "<title>"` / `wai write "<title>" <file>` — create/update pages');
+  parts.push('- `wai upload <file>` — upload a media file (image, audio, video) to the wiki');
+  parts.push('- `wai talk create "<title>" -s "<subject>" -c "<content>"` — post to talk page');
+  parts.push('- Use `jq` and `sqlite3` to query vault objects per the source page instructions');
+  parts.push('- Use `convert` / `montage` (ImageMagick) for image processing (contact sheets, thumbnails)');
+  parts.push('- Use `ffmpeg` / `ffprobe` for audio/video processing (extraction, thumbnails, duration)');
+  parts.push('');
+  parts.push('### Available API keys (in environment)');
+  parts.push('- `OPENAI_API_KEY` — OpenAI Whisper API for audio transcription (`https://api.openai.com/v1/audio/transcriptions`)');
+  parts.push('- `GOOGLE_PLACES_API_KEY` — Google Places / Geocoding API for reverse-geocoding coordinates to place names');
+  parts.push('');
+  parts.push('You are free to write scripts, install packages, and build tools as needed to process the data.');
+
+  return parts.join('\n');
+}

--- a/evals/src/harnesses/types.ts
+++ b/evals/src/harnesses/types.ts
@@ -1,0 +1,36 @@
+import type { TestCase, CheckpointSpec } from '../types.js';
+
+export interface HarnessRunOptions {
+  phase?: 'source' | 'content';
+  /** Incremental checkpoint specification */
+  checkpoint?: CheckpointSpec;
+  /** Zero-based index of the current checkpoint in the sequence */
+  checkpointIndex?: number;
+  /** Titles of pages already in the wiki from prior checkpoints */
+  priorPages?: string[];
+  /** Session ID from a previous run — harness may resume the session instead of starting fresh */
+  sessionId?: string;
+  /** Working directory from a previous run — reused when resuming a session */
+  cwd?: string;
+  /** Owner-provided anecdotes/corrections to include in the prompt */
+  ownerInput?: unknown[];
+  /** Per-checkpoint timeout in milliseconds (default: 30 minutes) */
+  timeoutMs?: number;
+}
+
+export interface HarnessResult {
+  output: string;
+  /** Agent session transcript / tool call log */
+  log: string;
+  /** Actual model used by the harness (resolved from default if not specified) */
+  model?: string;
+  /** Session ID for resuming this session in a subsequent run */
+  sessionId?: string;
+  /** Working directory used by this run */
+  cwd?: string;
+}
+
+export interface Harness {
+  name: string;
+  run(task: TestCase, env: Record<string, string | undefined>, options?: HarnessRunOptions): Promise<HarnessResult>;
+}

--- a/evals/src/index.ts
+++ b/evals/src/index.ts
@@ -1,0 +1,153 @@
+import 'dotenv/config';
+import { resolve } from 'node:path';
+import { gradeFixture } from './runner/grade.js';
+import { runE2E } from './runner/e2e.js';
+import { report, formatPageBreakdown, formatCheckpointBreakdown } from './reporter.js';
+
+const USAGE = `Usage:
+  tsx src/index.ts grade <fixture-dir> --page <file> [--rule-based-only] [--vault-path <path>]
+  tsx src/index.ts grade <fixture-dir> --pages <dir> [--rule-based-only] [--vault-path <path>]
+  tsx src/index.ts grade <fixture-dir> --result <result.json> [--graders <name,...>] [--rule-based-only] [--vault-path <path>]
+  tsx src/index.ts run --suite <name> --harness <name> [--model <name>] [--case <id>] [--external-wiki] [--inspect] [--checkpoint-threshold <n>] [--from-result <result.json>]
+  tsx src/index.ts report [results-dir]`;
+
+function parseArgs(args: string[]): { command: string; positional: string[]; flags: Record<string, string> } {
+  const command = args[0] ?? '';
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith('--')) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = 'true';
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { command, positional, flags };
+}
+
+function printScores(result: { scores: { grader: string; score: number; skipped?: boolean; details: { check: string; passed: boolean; penalty: number; note?: string }[] }[]; composite: number; pages?: import('./types.js').PageResult[]; checkpoints?: import('./types.js').CheckpointResult[] }): void {
+  console.log('\n=== Grading Results ===\n');
+
+  // Show checkpoint breakdown if available
+  if (result.checkpoints && result.checkpoints.length > 0) {
+    console.log('--- Checkpoint breakdown ---\n');
+    console.log(formatCheckpointBreakdown(result.checkpoints));
+    console.log();
+  }
+
+  // Show per-page breakdown if available
+  if (result.pages && result.pages.length > 1) {
+    console.log('--- Per-page breakdown ---\n');
+    console.log(formatPageBreakdown(result.pages));
+    console.log('\n--- Primary page scores ---\n');
+  }
+
+  for (const score of result.scores) {
+    const status = score.skipped ? ' (skipped)' : '';
+    console.log(`${score.grader}: ${score.score.toFixed(3)}${status}`);
+    for (const d of score.details) {
+      const icon = d.passed ? '+' : '-';
+      const note = d.note ? ` (${d.note})` : '';
+      console.log(`  [${icon}] ${d.check}${note}`);
+    }
+    console.log();
+  }
+
+  console.log(`Composite: ${result.composite.toFixed(3)}`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.log(USAGE);
+    process.exit(1);
+  }
+
+  const { command, positional, flags } = parseArgs(args);
+
+  switch (command) {
+    case 'grade': {
+      const fixtureDir = positional[0];
+      const page = flags['page'];
+      const pages = flags['pages'];
+      const resultFile = flags['result'];
+      if (!fixtureDir || (!page && !pages && !resultFile)) {
+        console.error('Error: fixture directory and --page, --pages, or --result are required');
+        console.log(USAGE);
+        process.exit(1);
+      }
+
+      const graders = flags['graders'] ? flags['graders'].split(',').map((s) => s.trim()) : undefined;
+
+      const result = await gradeFixture(resolve(fixtureDir), {
+        page,
+        pages,
+        result: resultFile,
+        ruleBasedOnly: flags['rule-based-only'] === 'true',
+        vaultPath: flags['vault-path'],
+        graders,
+      });
+
+      printScores(result);
+      break;
+    }
+
+    case 'run': {
+      const suite = flags['suite'];
+      const harness = flags['harness'];
+      if (!suite || !harness) {
+        console.error('Error: --suite and --harness are required');
+        console.log(USAGE);
+        process.exit(1);
+      }
+
+      const thresholdStr = flags['checkpoint-threshold'];
+      const checkpointThreshold = thresholdStr ? parseFloat(thresholdStr) : undefined;
+
+      const results = await runE2E({
+        suite,
+        harness,
+        model: flags['model'],
+        caseFilter: flags['case'],
+        externalWiki: flags['external-wiki'] === 'true',
+        inspect: flags['inspect'] === 'true',
+        checkpointThreshold,
+        fromResult: flags['from-result'],
+      });
+
+      console.log(`\nCompleted ${results.length} test case(s)`);
+      for (const r of results) {
+        printScores(r);
+      }
+      break;
+    }
+
+    case 'report': {
+      const resultsDir = positional[0] ?? 'results';
+      const output = report(resolve(resultsDir));
+      console.log(output);
+      break;
+    }
+
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.log(USAGE);
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/evals/src/llm.ts
+++ b/evals/src/llm.ts
@@ -1,0 +1,179 @@
+import { execFileSync } from 'node:child_process';
+
+export interface ClaimExtraction {
+  claims: { text: string; type: 'date' | 'location' | 'name' | 'fact'; source?: string }[];
+}
+
+export interface RubricEvaluation {
+  deductions: { category: string; description: string; penalty: number }[];
+  notes: string[];
+}
+
+export interface CrossRefExtraction {
+  crossRefs: { fact: string; sourceTypes: string[] }[];
+}
+
+function askClaude(prompt: string): string {
+  return execFileSync('claude', ['-p', '-', '--output-format', 'text'], {
+    input: prompt,
+    encoding: 'utf-8',
+  });
+}
+
+function parseJson<T>(raw: string): T {
+  // Strip markdown code fences if present
+  let text = raw.replace(/^```(?:json)?\s*\n?/m, '').replace(/\n?```\s*$/m, '').trim();
+
+  // Extract the first JSON object if there's extra text around it
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start !== -1 && end !== -1 && end > start) {
+    text = text.slice(start, end + 1);
+  }
+
+  return JSON.parse(text) as T;
+}
+
+export async function extractClaims(
+  wikitext: string,
+  sourceData: string,
+): Promise<ClaimExtraction> {
+  const prompt = `Extract all factual claims from this wikitext page. For each claim, identify its type (date, location, name, or fact) and check whether it is supported by the source data provided.
+
+Return a JSON object with this exact structure:
+{
+  "claims": [
+    { "text": "claim text", "type": "date|location|name|fact", "source": "supported|unsupported|fabricated" }
+  ]
+}
+
+A claim is "supported" if the source data contains evidence for it.
+A claim is "unsupported" if the source data doesn't mention it but it could be true.
+A claim is "fabricated" if the source data contradicts it.
+
+WIKITEXT:
+${wikitext}
+
+SOURCE DATA:
+${sourceData}
+
+Return only the JSON object, no other text.`;
+
+  const text = askClaude(prompt);
+  return parseJson<ClaimExtraction>(text);
+}
+
+export interface ClaimOnlyExtraction {
+  claims: { text: string; type: 'date' | 'location' | 'name' | 'fact' }[];
+}
+
+export async function extractClaimsOnly(
+  wikitext: string,
+): Promise<ClaimOnlyExtraction> {
+  const prompt = `Extract all concrete, verifiable factual claims from this wikitext page. Focus on specific dates, names, quantities, locations, and events — not opinions or vague statements.
+
+Return a JSON object with this exact structure:
+{
+  "claims": [
+    { "text": "claim text", "type": "date|location|name|fact" }
+  ]
+}
+
+WIKITEXT:
+${wikitext}
+
+Return only the JSON object, no other text.`;
+
+  const text = askClaude(prompt);
+  return parseJson<ClaimOnlyExtraction>(text);
+}
+
+export async function evaluateWithRubric(
+  wikitext: string,
+  rubric: string,
+): Promise<RubricEvaluation> {
+  const prompt = `Evaluate this wikitext page against the following rubric. Identify specific deductions.
+
+Return a JSON object with this exact structure:
+{
+  "deductions": [
+    { "category": "category name from rubric", "description": "what's wrong", "penalty": 0.1 }
+  ],
+  "notes": ["any general observations"]
+}
+
+Follow the deduction amounts specified in the rubric below.
+
+RUBRIC:
+${rubric}
+
+WIKITEXT:
+${wikitext}
+
+Return only the JSON object, no other text.`;
+
+  const text = askClaude(prompt);
+  return parseJson<RubricEvaluation>(text);
+}
+
+export interface ClaimValidation {
+  results: { claim: string; verdict: 'supported' | 'unsupported' | 'fabricated'; reason?: string }[];
+}
+
+export async function validateClaimBatch(
+  pairs: { claim: string; evidence: string }[],
+): Promise<ClaimValidation> {
+  const pairList = pairs
+    .map((p, i) => `${i + 1}. Claim: ${p.claim}\n   Evidence: ${p.evidence}`)
+    .join('\n\n');
+
+  const prompt = `You are a fact-checker. For each (claim, evidence) pair below, determine whether the evidence supports the claim.
+
+Return a JSON object with this exact structure:
+{
+  "results": [
+    { "claim": "claim text", "verdict": "supported|unsupported|fabricated", "reason": "brief explanation" }
+  ]
+}
+
+Verdicts:
+- "supported" — the evidence directly supports or is consistent with the claim
+- "unsupported" — the evidence doesn't mention or address the claim, OR the discrepancy is plausibly a timezone conversion error (e.g. times differ by exactly 1-6 hours matching common UTC offsets like UTC-5, UTC-6, UTC+1)
+- "fabricated" — the evidence directly contradicts the claim in a way that cannot be explained by timezone conversion (wrong names, wrong locations, wrong dates by more than 1 day, completely invented events)
+
+Important: Source data often mixes timezone representations (UTC, local time, device timezone). If a claimed time differs from the evidence by an offset consistent with a timezone conversion error, classify it as "unsupported" rather than "fabricated".
+
+CLAIM-EVIDENCE PAIRS:
+${pairList}
+
+Return only the JSON object, no other text.`;
+
+  const text = askClaude(prompt);
+  return parseJson<ClaimValidation>(text);
+}
+
+export async function extractCrossRefs(
+  wikitext: string,
+  sourceTypes: string[],
+): Promise<CrossRefExtraction> {
+  const prompt = `Analyze this wikitext page and identify facts that combine information from multiple data source types.
+
+The available source types are: ${sourceTypes.join(', ')}
+
+A cross-referenced fact is one where the page makes a claim that requires information from two or more distinct source types. For example, identifying a restaurant from a bank transaction cross-referenced with a GPS coordinate and a photo timestamp.
+
+Return a JSON object with this exact structure:
+{
+  "crossRefs": [
+    { "fact": "description of cross-referenced fact", "sourceTypes": ["type1", "type2"] }
+  ]
+}
+
+WIKITEXT:
+${wikitext}
+
+Return only the JSON object, no other text.`;
+
+  const text = askClaude(prompt);
+  return parseJson<CrossRefExtraction>(text);
+}

--- a/evals/src/reporter.ts
+++ b/evals/src/reporter.ts
@@ -1,0 +1,189 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { EvalResult, PageResult, CheckpointResult } from './types.js';
+
+interface AggregatedRow {
+  harness: string;
+  model: string;
+  suite: string;
+  scores: Record<string, number[]>;
+  composites: number[];
+}
+
+function loadResults(resultsDir: string): EvalResult[] {
+  const files = readdirSync(resultsDir).filter((f) => f.endsWith('.json'));
+  return files.map((f) => {
+    const content = readFileSync(join(resultsDir, f), 'utf-8');
+    return JSON.parse(content) as EvalResult;
+  });
+}
+
+function aggregate(results: EvalResult[]): AggregatedRow[] {
+  const groups = new Map<string, AggregatedRow>();
+
+  for (const result of results) {
+    const key = `${result.harness}|${result.model}|${result.suite}`;
+    let row = groups.get(key);
+    if (!row) {
+      row = {
+        harness: result.harness,
+        model: result.model,
+        suite: result.suite,
+        scores: {},
+        composites: [],
+      };
+      groups.set(key, row);
+    }
+
+    for (const score of result.scores) {
+      if (score.skipped) continue;
+      if (!row.scores[score.grader]) row.scores[score.grader] = [];
+      row.scores[score.grader].push(score.score);
+    }
+    row.composites.push(result.composite);
+  }
+
+  return [...groups.values()];
+}
+
+function avg(nums: number[]): string {
+  if (nums.length === 0) return '-';
+  const mean = nums.reduce((a, b) => a + b, 0) / nums.length;
+  return mean.toFixed(2);
+}
+
+function formatTable(rows: AggregatedRow[]): string {
+  if (rows.length === 0) return 'No results found.';
+
+  // Collect all grader names
+  const graderNames = new Set<string>();
+  for (const row of rows) {
+    for (const name of Object.keys(row.scores)) {
+      graderNames.add(name);
+    }
+  }
+  const graders = [...graderNames].sort();
+
+  // Build header
+  const headers = ['Harness', 'Model', 'Suite', ...graders.map(capitalize), 'Composite'];
+  const separator = headers.map((h) => '-'.repeat(Math.max(h.length, 6)));
+
+  const lines: string[] = [];
+  lines.push('| ' + headers.join(' | ') + ' |');
+  lines.push('| ' + separator.join(' | ') + ' |');
+
+  for (const row of rows) {
+    const cells = [
+      row.harness,
+      row.model,
+      row.suite,
+      ...graders.map((g) => avg(row.scores[g] ?? [])),
+      avg(row.composites),
+    ];
+    lines.push('| ' + cells.join(' | ') + ' |');
+  }
+
+  return lines.join('\n');
+}
+
+function formatDurationShort(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remainSecs = secs % 60;
+  if (mins < 60) return `${mins}m${remainSecs > 0 ? `${remainSecs}s` : ''}`;
+  const hours = Math.floor(mins / 60);
+  const remainMins = mins % 60;
+  return `${hours}h${remainMins > 0 ? `${remainMins}m` : ''}`;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function formatPageBreakdown(pages: PageResult[]): string {
+  const lines: string[] = [];
+  for (const page of pages) {
+    lines.push(`  [${page.role}] ${page.title}: ${page.composite.toFixed(3)}`);
+    for (const score of page.scores) {
+      const status = score.skipped ? ' (skipped)' : '';
+      lines.push(`    ${score.grader}: ${score.score.toFixed(3)}${status}`);
+      for (const d of score.details) {
+        const icon = d.passed ? '+' : '-';
+        const note = d.note ? ` (${d.note})` : '';
+        lines.push(`      [${icon}] ${d.check}${note}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+export function formatCheckpointBreakdown(checkpoints: CheckpointResult[]): string {
+  const lines: string[] = [];
+
+  // Show score progression bar when there are more than 2 checkpoints
+  if (checkpoints.length > 2) {
+    lines.push('  Score progression:');
+    const maxIdLen = Math.max(...checkpoints.map((cp) => cp.stage.length));
+    const barWidth = 20;
+    for (const cp of checkpoints) {
+      const filled = Math.round(cp.composite * barWidth);
+      const bar = '#'.repeat(filled) + '.'.repeat(barWidth - filled);
+      const idx = String(cp.checkpoint).padStart(2, ' ');
+      const stage = cp.stage.padEnd(maxIdLen, ' ');
+      const dur = cp.durationMs != null ? `  ${formatDurationShort(cp.durationMs)}` : '';
+      lines.push(`    ${idx}. ${stage}  [${bar}] ${cp.composite.toFixed(3)}${dur}`);
+    }
+    lines.push('');
+  }
+
+  for (const cp of checkpoints) {
+    const status = cp.passed ? 'PASS' : 'FAIL';
+    const dur = cp.durationMs != null ? ` (${formatDurationShort(cp.durationMs)})` : '';
+    lines.push(`  Checkpoint ${cp.checkpoint} (${cp.stage}): ${cp.composite.toFixed(3)} [${status}] (threshold: ${cp.threshold})${dur}`);
+    for (const page of cp.pages) {
+      lines.push(`    [${page.role}] ${page.title}: ${page.composite.toFixed(3)}`);
+      for (const score of page.scores) {
+        const skipNote = score.skipped ? ' (skipped)' : '';
+        lines.push(`      ${score.grader}: ${score.score.toFixed(3)}${skipNote}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+export function formatJson(resultsDir: string): string {
+  const results = loadResults(resultsDir);
+  const rows = aggregate(results);
+  return JSON.stringify(rows, null, 2);
+}
+
+export function formatMarkdown(resultsDir: string): string {
+  const results = loadResults(resultsDir);
+
+  // Group by suite
+  const bySuite = new Map<string, EvalResult[]>();
+  for (const r of results) {
+    const list = bySuite.get(r.suite) ?? [];
+    list.push(r);
+    bySuite.set(r.suite, list);
+  }
+
+  const parts: string[] = [];
+  for (const [suite, suiteResults] of bySuite) {
+    parts.push(`## ${capitalize(suite)}\n`);
+    const rows = aggregate(suiteResults);
+    parts.push(formatTable(rows));
+    parts.push('');
+  }
+
+  return parts.join('\n');
+}
+
+export function report(resultsDir: string, format: 'json' | 'markdown' = 'markdown'): string {
+  if (format === 'json') {
+    return formatJson(resultsDir);
+  }
+  return formatMarkdown(resultsDir);
+}

--- a/evals/src/runner/e2e.ts
+++ b/evals/src/runner/e2e.ts
@@ -1,0 +1,1090 @@
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, appendFileSync, existsSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { join, resolve, isAbsolute } from 'node:path';
+import { execSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import type { TestCase, EvalResult, PageResult, PageRole, CheckpointResult, CheckpointSpec, GradeTarget, ContentWeights } from '../types.js';
+import type { Harness } from '../harnesses/types.js';
+import { runGraders, computeComposite } from '../graders/index.js';
+import type { CitationManifest } from '../graders/accuracy.js';
+import { createClaudeCodeHarness } from '../harnesses/claude-code.js';
+import { createCodexHarness } from '../harnesses/codex.js';
+import { createOpenCodeHarness } from '../harnesses/opencode.js';
+import { startWiki, writePageDirect, type WikiInstance } from '../wiki.js';
+
+export interface E2EOptions {
+  suite: string;
+  harness: string;
+  model?: string;
+  /** Run only the test case with this ID */
+  caseFilter?: string;
+  /** Use an already-running wiki instead of spinning up an isolated instance */
+  externalWiki?: boolean;
+  /** Pause after grading so you can inspect the wiki before teardown */
+  inspect?: boolean;
+  fixturesDir?: string;
+  resultsDir?: string;
+  /** Override checkpoint threshold from case.json */
+  checkpointThreshold?: number;
+  /** Path to a previous result JSON — reuses checkpoint 1 source pages, skips Phase 1 */
+  fromResult?: string;
+}
+
+interface DiscoveredPage {
+  title: string;
+  role: PageRole;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remainSecs = secs % 60;
+  if (mins < 60) return `${mins}m${remainSecs > 0 ? ` ${remainSecs}s` : ''}`;
+  const hours = Math.floor(mins / 60);
+  const remainMins = mins % 60;
+  return `${hours}h${remainMins > 0 ? ` ${remainMins}m` : ''}`;
+}
+
+function getHarness(name: string, model?: string): Harness {
+  switch (name) {
+    case 'claude-code':
+      return createClaudeCodeHarness(model);
+    case 'codex':
+      return createCodexHarness(model);
+    case 'opencode':
+      return createOpenCodeHarness(model);
+    default:
+      throw new Error(`Unknown harness: ${name}`);
+  }
+}
+
+function loadTestCases(fixturesDir: string, suite: string): { testCase: TestCase; dir: string }[] {
+  const suiteDir = join(fixturesDir, suite);
+  const entries = readdirSync(suiteDir, { withFileTypes: true });
+  const cases: { testCase: TestCase; dir: string }[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const caseDir = join(suiteDir, entry.name);
+    try {
+      const caseJson = readFileSync(join(caseDir, 'case.json'), 'utf-8');
+      cases.push({ testCase: JSON.parse(caseJson), dir: caseDir });
+    } catch {
+      // Skip directories without case.json
+    }
+  }
+
+  return cases;
+}
+
+interface Logger {
+  log(msg: string): void;
+  error(msg: string): void;
+  path: string;
+}
+
+function createLogger(resultsDir: string): Logger {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const logPath = join(resultsDir, `run-${ts}.log`);
+  const write = (level: string, msg: string) => {
+    const line = `[${new Date().toISOString()}] [${level}] ${msg}\n`;
+    process.stderr.write(line);
+    appendFileSync(logPath, line);
+  };
+  return {
+    log: (msg: string) => write('INFO', msg),
+    error: (msg: string) => write('ERROR', msg),
+    path: logPath,
+  };
+}
+
+function waitForEnter(prompt: string): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    rl.question(prompt, () => {
+      rl.close();
+      resolve();
+    });
+  });
+}
+
+function execWai(args: string, env: Record<string, string | undefined>): string {
+  return execSync(`wai ${args}`, { env, encoding: 'utf-8' });
+}
+
+
+function readManifest(
+  log: Logger,
+  harnessCwd?: string,
+): CitationManifest | undefined {
+  if (!harnessCwd) {
+    log.log('No harness cwd — cannot read citation manifest');
+    return undefined;
+  }
+
+  const candidatePaths = [
+    join(harnessCwd, 'citation-manifest.json'),
+    join(harnessCwd, 'Citation-manifest.json'),
+  ];
+
+  for (const filePath of candidatePaths) {
+    try {
+      if (existsSync(filePath)) {
+        const raw = readFileSync(filePath, 'utf-8');
+        const manifest = JSON.parse(raw) as CitationManifest;
+        if (manifest.claims && manifest.claims.length > 0) {
+          log.log(`Read citation manifest from ${filePath}: ${manifest.claims.length} claims`);
+          return manifest;
+        }
+      }
+    } catch {
+      // Not valid JSON, try next
+    }
+  }
+
+  log.log('No citation manifest found on filesystem');
+  return undefined;
+}
+
+function readWikiPage(pageTitle: string, env: Record<string, string | undefined>): string {
+  return execWai(`read "${pageTitle}" --raw`, env);
+}
+
+function writeWikiPage(pageTitle: string, wikitext: string, env: Record<string, string | undefined>): void {
+  try {
+    execSync(`wai write "${pageTitle}" -`, { env, encoding: 'utf-8', input: wikitext, timeout: 120_000 });
+  } catch (err: unknown) {
+    // wai write exits 1 when content is identical ("No changes") — ignore that
+    const stderr = (err as { stderr?: string }).stderr ?? '';
+    if (!stderr.includes('No changes')) throw err;
+  }
+}
+
+function restoreSourcePages(
+  resultPath: string,
+  env: Record<string, string | undefined>,
+  log: Logger,
+): CheckpointResult {
+  const raw = readFileSync(resultPath, 'utf-8');
+  const prev: EvalResult = JSON.parse(raw);
+
+  const cp1 = prev.checkpoints?.find((c) => c.checkpoint === 1);
+  if (!cp1 || !cp1.passed) {
+    throw new Error('Previous result has no passing checkpoint 1');
+  }
+
+  const dataPath = env['WIKI_DATA_PATH'];
+  const confPath = dataPath ? join(dataPath, 'LocalSettings.php') : undefined;
+  for (const page of cp1.pages) {
+    log.log(`Restoring "${page.title}" (${page.wikitext.length} chars)`);
+    if (confPath) {
+      writePageDirect(confPath, page.title, page.wikitext);
+    } else {
+      writeWikiPage(page.title, page.wikitext, env);
+    }
+  }
+
+  return cp1;
+}
+
+function discoverAllPages(env: Record<string, string | undefined>): { title: string; ns: number }[] {
+  let changesJson: string;
+  try {
+    changesJson = execWai('changes -n 200 --json', env);
+  } catch {
+    return [];
+  }
+  try {
+    return JSON.parse(changesJson);
+  } catch {
+    return [];
+  }
+}
+
+function discoverSourcePages(env: Record<string, string | undefined>): DiscoveredPage[] {
+  const changes = discoverAllPages(env);
+  const seen = new Set<string>();
+  const pages: DiscoveredPage[] = [];
+
+  for (const change of changes) {
+    if (seen.has(change.title)) continue;
+    seen.add(change.title);
+
+    if (/^Source:/i.test(change.title)) {
+      pages.push({ title: change.title, role: 'source' });
+    }
+  }
+
+  return pages;
+}
+
+function discoverContentPages(env: Record<string, string | undefined>, subject: string): DiscoveredPage[] {
+  const changes = discoverAllPages(env);
+  const seen = new Set<string>();
+  const pages: DiscoveredPage[] = [];
+
+  for (const change of changes) {
+    if (seen.has(change.title)) continue;
+    seen.add(change.title);
+
+    // Skip Source:, Task:, and default Main Page
+    if (/^(Source|Task):/i.test(change.title)) continue;
+    if (change.title === 'Main Page') continue;
+
+    // Talk namespace
+    if (/^Talk:/i.test(change.title) || change.ns === 1) {
+      pages.push({ title: change.title, role: 'talk' });
+      continue;
+    }
+
+    // Main namespace — classify as person or episode
+    if (change.ns === 0 || !change.title.includes(':')) {
+      const role: PageRole = change.title === subject ? 'person' : 'episode';
+      pages.push({ title: change.title, role });
+    }
+  }
+
+  return pages;
+}
+
+/**
+ * Discover wiki pages that match a set of GradeTarget patterns.
+ * Uses the existing matchReferenceKey helper for glob matching.
+ *
+ * When a non-glob content target (person, episode, talk) has no exact match,
+ * falls back to matching any main-namespace page whose title contains the
+ * pattern text (case-insensitive). This handles agents that choose a different
+ * but related page title (e.g. "Mexico City, March 2022" vs "CDMX trip").
+ */
+function discoverPagesForTargets(
+  targets: GradeTarget[],
+  env: Record<string, string | undefined>,
+): DiscoveredPage[] {
+  const changes = discoverAllPages(env);
+  const seen = new Set<string>();
+  const pages: DiscoveredPage[] = [];
+
+  // First pass: exact/glob matching
+  for (const change of changes) {
+    if (seen.has(change.title)) continue;
+    if (change.title === 'Main Page') continue;
+
+    for (const target of targets) {
+      if (matchReferenceKey(change.title, target.pattern)) {
+        seen.add(change.title);
+        pages.push({ title: change.title, role: target.role });
+        break;
+      }
+    }
+  }
+
+  // Second pass: fuzzy fallback for unmatched content targets.
+  // For each target that found no match and isn't a glob pattern,
+  // look for any non-source page in the wiki that could be the intended page.
+  const matchedRoles = new Set(pages.map((p) => p.role));
+  for (const target of targets) {
+    // Skip source targets and glob patterns — those should match exactly
+    if (target.role === 'source') continue;
+    if (target.pattern.includes('*')) continue;
+    // Skip if this target already matched
+    if (pages.some((p) => matchReferenceKey(p.title, target.pattern))) continue;
+
+    // Find candidate pages in the right namespace
+    const isTalk = target.pattern.startsWith('Talk:');
+    for (const change of changes) {
+      if (seen.has(change.title)) continue;
+      if (change.title === 'Main Page') continue;
+      if (/^(Source|Task):/i.test(change.title)) continue;
+
+      const pageIsTalk = /^Talk:/i.test(change.title);
+      if (isTalk !== pageIsTalk) continue;
+
+      // Accept the first non-source page in the matching namespace
+      seen.add(change.title);
+      pages.push({ title: change.title, role: target.role });
+      break;
+    }
+  }
+
+  return pages;
+}
+
+/**
+ * Match a page title against a references map key.
+ * Supports exact match and glob-style prefix match (e.g. "Source:Facebook/*").
+ */
+function matchReferenceKey(pageTitle: string, pattern: string): boolean {
+  if (pattern === pageTitle) return true;
+  if (pattern.endsWith('/*')) {
+    const prefix = pattern.slice(0, -1); // "Source:Facebook/"
+    return pageTitle.startsWith(prefix) || pageTitle === prefix.slice(0, -1);
+  }
+  // Bare glob: "Source:*" matches anything starting with "Source:"
+  if (pattern.endsWith(':*')) {
+    const prefix = pattern.slice(0, -1); // "Source:"
+    return pageTitle.startsWith(prefix);
+  }
+  return false;
+}
+
+/**
+ * Load reference wikitext for a page given the test case references map.
+ *
+ * Resolution order:
+ * 1. testCase.references map (exact match, then glob prefix match)
+ * 2. testCase.reference field for person role (backward compat)
+ * 3. Implicit reference.wikitext in fixture dir for person role
+ */
+function loadReferenceWikitext(
+  testCase: TestCase,
+  fixtureDir: string,
+  pageTitle: string,
+  role: PageRole,
+): string | undefined {
+  // 1. Check references map
+  if (testCase.references) {
+    for (const [pattern, refPath] of Object.entries(testCase.references)) {
+      if (matchReferenceKey(pageTitle, pattern)) {
+        const absPath = isAbsolute(refPath) ? refPath : join(fixtureDir, refPath);
+        try {
+          return readFileSync(absPath, 'utf-8');
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  // 2. Backward compat: testCase.reference field for person role
+  if (role === 'person' && testCase.reference) {
+    const refPath = isAbsolute(testCase.reference) ? testCase.reference : join(fixtureDir, testCase.reference);
+    try {
+      return readFileSync(refPath, 'utf-8');
+    } catch {
+      return undefined;
+    }
+  }
+
+  // 3. Implicit reference.wikitext in fixture dir for person role
+  if (role === 'person') {
+    const implicitPath = join(fixtureDir, 'reference.wikitext');
+    if (existsSync(implicitPath)) {
+      try {
+        return readFileSync(implicitPath, 'utf-8');
+      } catch {
+        return undefined;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function computeWeightedComposite(pageResults: PageResult[], hasExpectedEpisodes: boolean, weights?: ContentWeights): number {
+  const person = pageResults.find((p) => p.role === 'person') ?? pageResults.find((p) => p.role === 'project');
+  const episodes = pageResults.filter((p) => p.role === 'episode');
+  const talk = pageResults.find((p) => p.role === 'talk');
+
+  let primaryWeight: number;
+  let episodeWeight: number;
+  let talkWeight: number;
+
+  if (weights) {
+    primaryWeight = weights.primary;
+    episodeWeight = weights.episodes;
+    talkWeight = weights.talk;
+  } else if (hasExpectedEpisodes || episodes.length > 0) {
+    primaryWeight = 0.5;
+    episodeWeight = 0.4;
+    talkWeight = 0.1;
+  } else {
+    primaryWeight = 0.85;
+    episodeWeight = 0;
+    talkWeight = 0.15;
+  }
+
+  // If no talk page, redistribute to primary
+  if (!talk) {
+    primaryWeight += talkWeight;
+    talkWeight = 0;
+  }
+
+  // Primary page is person/project if it exists, otherwise the first episode
+  const primary = person ?? (episodes.length > 0 ? episodes[0] : undefined);
+  const extraEpisodes = person ? episodes : episodes.slice(1);
+
+  let weighted = 0;
+  if (primary) weighted += primary.composite * primaryWeight;
+  if (extraEpisodes.length > 0) {
+    const avgEpisode = extraEpisodes.reduce((sum, e) => sum + e.composite, 0) / extraEpisodes.length;
+    weighted += avgEpisode * episodeWeight;
+  }
+  if (talk) weighted += talk.composite * talkWeight;
+
+  return Math.round(weighted * 1000) / 1000;
+}
+
+function configureWaiCredentials(wiki: WikiInstance): void {
+  const configDir = join(homedir(), '.whoami');
+  mkdirSync(configDir, { recursive: true });
+
+  const credPath = join(configDir, 'credentials.json');
+  const credentials = JSON.stringify({
+    server: wiki.url,
+    username: wiki.username,
+    password: wiki.password,
+  }, null, 2);
+  writeFileSync(credPath, credentials + '\n', { mode: 0o600 });
+}
+
+async function gradePages(
+  pages: DiscoveredPage[],
+  testCase: TestCase,
+  fixtureDir: string,
+  sourceData: string,
+  subject: string,
+  env: Record<string, string | undefined>,
+  log: Logger,
+  harnessLog?: string,
+  manifest?: CitationManifest,
+  previousWikitextMap?: Map<string, string>,
+  checkpointId?: string,
+  skipReference?: boolean,
+): Promise<PageResult[]> {
+  // Pass 1: Read all pages so talk page content is available for integration grading
+  const pageContents = new Map<string, string>();
+  for (const page of pages) {
+    log.log(`Reading page "${page.title}"`);
+    try {
+      const wikitext = readWikiPage(page.title, env);
+      log.log(`Read OK (${wikitext.length} chars)`);
+      pageContents.set(page.title, wikitext);
+    } catch (err) {
+      log.error(`Could not read page "${page.title}": ${err}`);
+    }
+  }
+
+  // Find talk page wikitext (for integration grading of person/episode pages)
+  const talkPage = pages.find((p) => p.role === 'talk');
+  const talkWikitext = talkPage ? pageContents.get(talkPage.title) : undefined;
+
+  // Pass 2: Grade all pages
+  const pageResults: PageResult[] = [];
+
+  for (const page of pages) {
+    const wikitext = pageContents.get(page.title);
+    if (!wikitext) continue;
+
+    const referenceWikitext = skipReference
+      ? undefined
+      : loadReferenceWikitext(testCase, fixtureDir, page.title, page.role);
+    if (referenceWikitext) {
+      log.log(`Loaded reference for "${page.title}" (${referenceWikitext.length} chars)`);
+    }
+
+    const previousWikitext = previousWikitextMap?.get(page.title);
+
+    const vaultPath = env['WAI_VAULT_PATH'];
+    log.log(`Grading ${page.role} page "${page.title}"`);
+    try {
+      const scores = await runGraders(wikitext, testCase, sourceData, {
+        role: page.role,
+        subject,
+        expectedEpisodes: testCase.expectedEpisodes,
+        referenceWikitext,
+        vault: vaultPath ? { vaultPath } : undefined,
+        log: harnessLog,
+        manifest,
+        previousWikitext,
+        checkpointId,
+        skipReference,
+        talkWikitext: (page.role === 'person' || page.role === 'project' || page.role === 'episode') ? talkWikitext : undefined,
+      });
+      const composite = computeComposite(scores);
+      log.log(`${page.role} "${page.title}" → ${composite.toFixed(3)}`);
+
+      pageResults.push({
+        title: page.title,
+        role: page.role,
+        wikitext,
+        scores,
+        composite,
+      });
+    } catch (err) {
+      log.error(`Grading failed for ${page.role} page "${page.title}": ${err}`);
+      // Record the page with zero score so the run can continue
+      pageResults.push({
+        title: page.title,
+        role: page.role,
+        wikitext,
+        scores: [],
+        composite: 0,
+      });
+    }
+  }
+
+  return pageResults;
+}
+
+/**
+ * Run the incremental checkpoint loop for a test case with CheckpointSpec[].
+ * Each checkpoint: snapshot new sources → invoke harness → discover & grade target pages → gate.
+ */
+async function runCheckpointLoop(
+  testCase: TestCase,
+  dir: string,
+  harness: Harness,
+  env: Record<string, string | undefined>,
+  options: E2EOptions,
+  log: Logger,
+): Promise<{ checkpoints: CheckpointResult[]; allPageResults: PageResult[]; harnessLogs: string[]; resolvedModel?: string }> {
+  const specs = testCase.checkpoints!;
+  const checkpoints: CheckpointResult[] = [];
+  const latestPageScores = new Map<string, PageResult>();
+  const priorPageTitles: string[] = [];
+  const harnessLogs: string[] = [];
+  let resolvedModel: string | undefined;
+  let manifest: CitationManifest | undefined;
+  let harnessSessionId: string | undefined;
+  let harnessCwd: string | undefined;
+
+  const subject = testCase.subject ?? testCase.id;
+
+  // fromResult support: restore all passing checkpoints from a previous result
+  let startIndex = 0;
+  if (options.fromResult) {
+    const raw = readFileSync(options.fromResult, 'utf-8');
+    const prev: EvalResult = JSON.parse(raw);
+
+    if (prev.checkpoints) {
+      // Collect latest version of each page across all passing checkpoints
+      const pagesToRestore = new Map<string, { page: PageResult }>();
+      for (const cp of prev.checkpoints) {
+        if (!cp.passed) break;
+        checkpoints.push(cp);
+        for (const page of cp.pages) {
+          pagesToRestore.set(page.title, { page });
+          latestPageScores.set(page.title, page);
+          if (!priorPageTitles.includes(page.title)) {
+            priorPageTitles.push(page.title);
+          }
+        }
+        startIndex++;
+      }
+
+      // Write only the latest version of each page (avoids duplicate writes)
+      // Use PHP CLI directly when available (faster, no HTTP timeout issues)
+      const dataPath = env['WIKI_DATA_PATH'];
+      const confPath = dataPath ? join(dataPath, 'LocalSettings.php') : undefined;
+      for (const [title, { page }] of pagesToRestore) {
+        log.log(`Restoring "${title}" (${page.wikitext.length} chars)`);
+        if (confPath) {
+          writePageDirect(confPath, title, page.wikitext);
+        } else {
+          writeWikiPage(title, page.wikitext, env);
+        }
+      }
+      log.log(`Restored ${startIndex} passing checkpoint(s) (${pagesToRestore.size} unique pages) from previous result`);
+
+      // Snapshot all sources introduced up to the restored point
+      // so the vault is populated for the accuracy grader
+      for (let i = 0; i < startIndex; i++) {
+        const cpSources = specs[i].sources ?? [];
+        for (const source of cpSources) {
+          const sourcePath = isAbsolute(source.path) ? source.path : join(dir, source.path);
+          log.log(`Snapshotting ${sourcePath} into vault`);
+          try {
+            execWai(`snapshot "${sourcePath}"`, env);
+          } catch (err) {
+            log.error(`Snapshot failed for ${sourcePath}: ${err}`);
+          }
+        }
+      }
+    }
+  }
+
+  for (let i = startIndex; i < specs.length; i++) {
+    const spec = specs[i];
+    const cpStart = Date.now();
+    log.log(`--- Checkpoint ${i + 1}/${specs.length}: ${spec.id} ---`);
+
+    // Snapshot current wikitext of pages that will be graded (for integration grading)
+    const previousWikitextMap = new Map<string, string>();
+    const targetPagesPreSnapshot = discoverPagesForTargets(spec.grade, env);
+    for (const page of targetPagesPreSnapshot) {
+      try {
+        const wikitext = readWikiPage(page.title, env);
+        if (wikitext.trim().length > 0) {
+          previousWikitextMap.set(page.title, wikitext);
+        }
+      } catch {
+        // Page doesn't exist yet — no previous wikitext
+      }
+    }
+    // Also include any pages from latestPageScores that match grade targets
+    for (const [title, pr] of latestPageScores) {
+      if (!previousWikitextMap.has(title)) {
+        previousWikitextMap.set(title, pr.wikitext);
+      }
+    }
+
+    // Load owner anecdotes if specified
+    let ownerInput: unknown[] | undefined;
+    if (spec.ownerInput) {
+      try {
+        const ownerPath = join(dir, spec.ownerInput);
+        const ownerJson = readFileSync(ownerPath, 'utf-8');
+        const parsed = JSON.parse(ownerJson);
+        ownerInput = parsed.entries ?? [];
+        log.log(`Loaded ${(ownerInput as unknown[]).length} owner anecdote(s) from ${spec.ownerInput}`);
+      } catch (err) {
+        log.error(`Failed to load owner anecdotes from ${spec.ownerInput}: ${err}`);
+      }
+    }
+
+    // Invoke harness (the agent handles snapshotting via `wai snapshot`)
+    log.log(`Invoking harness (${spec.id}) — ${harness.name}${harnessSessionId ? ` (resuming ${harnessSessionId.slice(0, 8)}…)` : ''}`);
+    try {
+      const result = await harness.run(testCase, env, {
+        checkpoint: spec,
+        checkpointIndex: i,
+        priorPages: [...priorPageTitles],
+        sessionId: harnessSessionId,
+        cwd: harnessCwd,
+        ownerInput,
+      });
+      if (result.log) harnessLogs.push(result.log);
+      if (result.model) resolvedModel = result.model;
+      if (result.sessionId) harnessSessionId = result.sessionId;
+      if (result.cwd) harnessCwd = result.cwd;
+      log.log(`Harness finished for checkpoint ${spec.id}`);
+    } catch (err) {
+      log.error(`Harness failed for checkpoint ${spec.id}: ${err}`);
+      // Record a zero-score checkpoint and stop
+      checkpoints.push({
+        checkpoint: i + 1,
+        stage: spec.id,
+        pages: [],
+        composite: 0,
+        passed: false,
+        threshold: spec.threshold ?? 0,
+        durationMs: Date.now() - cpStart,
+      });
+      break;
+    }
+
+    // Read citation manifest if this is the verify checkpoint
+    if (spec.id === 'verify' || spec.produceManifest) {
+      manifest = readManifest(log, harnessCwd);
+    }
+
+    // Discover and grade target pages
+    const targetPages = discoverPagesForTargets(spec.grade, env);
+    log.log(`Discovered ${targetPages.length} page(s) for checkpoint ${spec.id}: ${targetPages.map((p) => p.title).join(', ') || '(none)'}`);
+
+    if (targetPages.length === 0 && spec.grade.length > 0) {
+      log.log(`WARNING: checkpoint ${spec.id} expected pages matching ${spec.grade.map((g) => g.pattern).join(', ')} but found none`);
+    }
+
+    const pageResults = await gradePages(
+      targetPages,
+      testCase,
+      dir,
+      '',
+      subject,
+      env,
+      log,
+      harnessLogs.join('\n'),
+      manifest,
+      previousWikitextMap,
+      spec.id,
+      spec.skipReference,
+    );
+
+    // Update latest scores map
+    for (const pr of pageResults) {
+      latestPageScores.set(pr.title, pr);
+      if (!priorPageTitles.includes(pr.title)) {
+        priorPageTitles.push(pr.title);
+      }
+    }
+
+    // Compute checkpoint composite (average of graded pages)
+    const cpComposite = pageResults.length > 0
+      ? Math.round((pageResults.reduce((sum, p) => sum + p.composite, 0) / pageResults.length) * 1000) / 1000
+      : 0;
+
+    const threshold = spec.threshold ?? 0;
+    const passed = threshold === 0 || cpComposite >= threshold;
+
+    const cpDuration = Date.now() - cpStart;
+    checkpoints.push({
+      checkpoint: i + 1,
+      stage: spec.id,
+      pages: pageResults,
+      composite: cpComposite,
+      passed,
+      threshold,
+      durationMs: cpDuration,
+    });
+
+    log.log(`Checkpoint ${i + 1} (${spec.id}): ${cpComposite.toFixed(3)}${threshold > 0 ? ` ${passed ? '>=' : '<'} ${threshold}` : ''} → ${passed ? 'PASS' : 'FAIL'} (${formatDuration(cpDuration)})`);
+
+    if (!passed) {
+      log.log(`Stopping — checkpoint ${spec.id} below threshold`);
+      break;
+    }
+  }
+
+  // Collect the latest version of all graded pages
+  const allPageResults = [...latestPageScores.values()];
+
+  return { checkpoints, allPageResults, harnessLogs, resolvedModel };
+}
+
+async function runCases(
+  cases: { testCase: TestCase; dir: string }[],
+  harness: Harness,
+  env: Record<string, string | undefined>,
+  options: E2EOptions,
+  resultsDir: string,
+  log: Logger,
+): Promise<EvalResult[]> {
+  const results: EvalResult[] = [];
+
+  for (const { testCase, dir } of cases) {
+    const caseStart = Date.now();
+    log.log(`=== Case ${testCase.id}: ${testCase.description} ===`);
+
+    // Step 1: Create task
+    let taskId: string;
+    log.log('Creating task');
+    try {
+      const taskOutput = execWai(`task create -m "${testCase.description}"`, env);
+      const idMatch = taskOutput.match(/(\d{4})/);
+      taskId = idMatch ? idMatch[1] : 'unknown';
+      log.log(`Task created: ${taskId}`);
+    } catch (err) {
+      log.error(`Failed to create task for ${testCase.id}: ${err}`);
+      continue;
+    }
+
+    const subject = testCase.subject ?? testCase.description.split(':').pop()?.trim() ?? testCase.id;
+    const threshold = options.checkpointThreshold ?? testCase.checkpointThreshold ?? 0.7;
+
+    // Incremental checkpoint path
+    if (testCase.checkpoints) {
+      log.log('Using incremental checkpoint loop');
+      const { checkpoints, allPageResults, harnessLogs, resolvedModel } = await runCheckpointLoop(
+        testCase, dir, harness, env, options, log,
+      );
+
+      // Compute final composite: 20% source pages, 80% content pages (same split as 2-phase)
+      const sourcePages = allPageResults.filter((p) => p.role === 'source');
+      const contentPages = allPageResults.filter((p) => p.role !== 'source');
+
+      let composite: number;
+      const sourceFraction = testCase.weights?.source ?? 0.2;
+      if (sourcePages.length > 0 && contentPages.length > 0) {
+        const sourceAvg = sourcePages.reduce((sum, p) => sum + p.composite, 0) / sourcePages.length;
+        const contentComposite = contentPages.length === 1
+          ? contentPages[0].composite
+          : computeWeightedComposite(contentPages, (testCase.expectedEpisodes?.length ?? 0) > 0, testCase.weights);
+        composite = Math.round((sourceAvg * sourceFraction + contentComposite * (1 - sourceFraction)) * 1000) / 1000;
+      } else if (allPageResults.length > 0) {
+        composite = Math.round((allPageResults.reduce((sum, p) => sum + p.composite, 0) / allPageResults.length) * 1000) / 1000;
+      } else {
+        composite = 0;
+      }
+
+      const primaryPage = allPageResults.find((p) => p.role === 'person')
+        ?? allPageResults.find((p) => p.role === 'project')
+        ?? allPageResults.find((p) => p.role === 'episode')
+        ?? allPageResults[0];
+
+      const caseDuration = Date.now() - caseStart;
+      const result: EvalResult = {
+        caseId: testCase.id,
+        suite: options.suite,
+        harness: harness.name,
+        model: resolvedModel ?? options.model ?? 'default',
+        output: primaryPage?.wikitext ?? '',
+        scores: primaryPage?.scores ?? [],
+        composite,
+        timestamp: new Date().toISOString(),
+        pages: allPageResults,
+        checkpoints,
+        durationMs: caseDuration,
+        log: harnessLogs.join('\n') || undefined,
+      };
+
+      results.push(result);
+
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const resultPath = join(resultsDir, `${testCase.id}-${harness.name}-${ts}.json`);
+      writeFileSync(resultPath, JSON.stringify(result, null, 2));
+      log.log(`Result written to ${resultPath}`);
+
+      log.log(`Model: ${resolvedModel ?? options.model ?? 'default'}`);
+      log.log(`Composite: ${composite} (${formatDuration(caseDuration)})`);
+      for (const pr of allPageResults) {
+        log.log(`  ${pr.role}: ${pr.title} → ${pr.composite.toFixed(3)}`);
+      }
+      continue;
+    }
+
+    let sourceData = '';
+
+    // Step 3: Two-phase harness invocation with checkpoint gating
+    const checkpoints: CheckpointResult[] = [];
+    const allPageResults: PageResult[] = [];
+    let output = '';
+    let checkpoint1Failed = false;
+    const harnessLogs: string[] = [];
+    let resolvedModel: string | undefined;
+
+    if (options.fromResult) {
+      // Restore source pages from a previous result, skip Phase 1 harness
+      log.log(`Restoring checkpoint 1 from ${options.fromResult}`);
+      const prevCp1 = restoreSourcePages(options.fromResult, env, log);
+      checkpoints.push(prevCp1);
+      allPageResults.push(...prevCp1.pages);
+      checkpoint1Failed = !prevCp1.passed;
+      log.log(`Checkpoint 1 (restored): ${prevCp1.composite.toFixed(3)} → ${prevCp1.passed ? 'PASS' : 'FAIL'}`);
+
+      // Populate the vault by snapshotting source directories.
+      // This is cheap I/O (no LLM) — just hashing files into the vault
+      // so the accuracy grader can resolve citations against real data.
+      for (const source of testCase.sources) {
+        const sourcePath = isAbsolute(source.path) ? source.path : join(dir, source.path);
+        log.log(`Snapshotting ${sourcePath} into vault`);
+        try {
+          execWai(`snapshot "${sourcePath}"`, env);
+        } catch (err) {
+          log.error(`Snapshot failed for ${sourcePath}: ${err}`);
+        }
+      }
+    } else {
+      // PHASE 1: Invoke harness for source enrichment
+      log.log(`Phase 1: Invoking harness (source) — ${harness.name}`);
+      try {
+        const result = await harness.run(testCase, env, { phase: 'source' });
+        if (result.log) harnessLogs.push(result.log);
+        if (result.model) resolvedModel = result.model;
+        log.log('Phase 1 harness finished');
+      } catch (err) {
+        log.error(`Phase 1 harness failed for ${testCase.id}: ${err}`);
+        continue;
+      }
+
+      // CHECKPOINT 1 — Grade source pages
+      log.log(`Discovering source pages (subject: "${subject}")`);
+      const sourcePages = discoverSourcePages(env);
+      log.log(`Discovered ${sourcePages.length} source page(s): ${sourcePages.map((p) => p.title).join(', ') || '(none)'}`);
+
+      if (sourcePages.length > 0) {
+        const sourceResults = await gradePages(sourcePages, testCase, dir, sourceData, subject, env, log, harnessLogs.join('\n'));
+        allPageResults.push(...sourceResults);
+
+        const sourceComposite = sourceResults.length > 0
+          ? Math.round((sourceResults.reduce((sum, p) => sum + p.composite, 0) / sourceResults.length) * 1000) / 1000
+          : 0;
+        const passed = sourceComposite >= threshold;
+
+        checkpoints.push({
+          checkpoint: 1,
+          stage: 'source',
+          pages: sourceResults,
+          composite: sourceComposite,
+          passed,
+          threshold,
+        });
+
+        log.log(`Checkpoint 1 (source): ${sourceComposite.toFixed(3)} ${passed ? '>=' : '<'} ${threshold} → ${passed ? 'PASS' : 'FAIL'}`);
+        checkpoint1Failed = !passed;
+      }
+    }
+
+    // PHASE 2: Invoke harness for content pages (skip if checkpoint 1 failed)
+    let contentResults: PageResult[] = [];
+    if (!checkpoint1Failed) {
+      log.log(`Phase 2: Invoking harness (content) — ${harness.name}`);
+      try {
+        const result = await harness.run(testCase, env, { phase: 'content' });
+        if (result.log) harnessLogs.push(result.log);
+        if (result.model) resolvedModel = result.model;
+        log.log('Phase 2 harness finished');
+      } catch (err) {
+        log.error(`Phase 2 harness failed for ${testCase.id}: ${err}`);
+        // Continue to grade whatever content pages may exist
+      }
+
+      // CHECKPOINT 2 — Grade content pages
+      log.log(`Discovering content pages (subject: "${subject}")`);
+      const contentPages = discoverContentPages(env, subject);
+      log.log(`Discovered ${contentPages.length} content page(s): ${contentPages.map((p) => `${p.role}:${p.title}`).join(', ') || '(none)'}`);
+
+      if (contentPages.length > 0) {
+        contentResults = await gradePages(contentPages, testCase, dir, sourceData, subject, env, log, harnessLogs.join('\n'));
+        allPageResults.push(...contentResults);
+
+        const contentComposite = contentResults.length === 1
+          ? contentResults[0].composite
+          : computeWeightedComposite(contentResults, (testCase.expectedEpisodes?.length ?? 0) > 0, testCase.weights);
+
+        checkpoints.push({
+          checkpoint: 2,
+          stage: 'content',
+          pages: contentResults,
+          composite: contentComposite,
+          passed: true,
+          threshold,
+        });
+
+        log.log(`Checkpoint 2 (content): ${contentComposite.toFixed(3)}`);
+      }
+    } else {
+      log.log('Skipping phase 2 — source quality below threshold');
+    }
+
+    // Fallback: if no pages discovered at all, read the primary page directly
+    if (allPageResults.length === 0) {
+      const pageTitle = subject;
+      log.log(`No pages discovered, falling back to reading "${pageTitle}"`);
+      try {
+        output = readWikiPage(pageTitle, env);
+      } catch {
+        log.error(`Could not read fallback page "${pageTitle}", using harness output`);
+      }
+
+      const referenceWikitext = loadReferenceWikitext(testCase, dir, pageTitle, 'person');
+      const fallbackVaultPath = env['WAI_VAULT_PATH'];
+      const scores = await runGraders(output, testCase, sourceData, {
+        referenceWikitext,
+        vault: fallbackVaultPath ? { vaultPath: fallbackVaultPath } : undefined,
+        log: harnessLogs.join('\n'),
+      });
+      const composite = computeComposite(scores);
+
+      allPageResults.push({
+        title: pageTitle,
+        role: 'person',
+        wikitext: output,
+        scores,
+        composite,
+      });
+    }
+
+    // Step 5: Compute final composite
+    let composite: number;
+    const hasCheckpoints = checkpoints.length > 0;
+
+    const sourceFraction2 = testCase.weights?.source ?? 0.2;
+    if (hasCheckpoints) {
+      const cp1 = checkpoints.find((c) => c.checkpoint === 1);
+      const cp2 = checkpoints.find((c) => c.checkpoint === 2);
+
+      if (cp1 && cp2) {
+        composite = Math.round((cp1.composite * sourceFraction2 + cp2.composite * (1 - sourceFraction2)) * 1000) / 1000;
+      } else if (cp1 && !cp1.passed) {
+        composite = Math.round((cp1.composite * sourceFraction2) * 1000) / 1000;
+      } else if (cp1) {
+        composite = Math.round((cp1.composite * sourceFraction2) * 1000) / 1000;
+      } else {
+        composite = allPageResults.length === 1
+          ? allPageResults[0].composite
+          : computeWeightedComposite(allPageResults, (testCase.expectedEpisodes?.length ?? 0) > 0, testCase.weights);
+      }
+    } else {
+      const hasExpectedEpisodes = (testCase.expectedEpisodes?.length ?? 0) > 0;
+      composite = allPageResults.length === 1
+        ? allPageResults[0].composite
+        : computeWeightedComposite(allPageResults, hasExpectedEpisodes, testCase.weights);
+    }
+
+    // Primary page for backward compat
+    const primaryPage = allPageResults.find((p) => p.role === 'person')
+      ?? allPageResults.find((p) => p.role === 'project')
+      ?? allPageResults[0];
+
+    const caseDuration = Date.now() - caseStart;
+    const result: EvalResult = {
+      caseId: testCase.id,
+      suite: options.suite,
+      harness: harness.name,
+      model: resolvedModel ?? options.model ?? 'default',
+      output: primaryPage.wikitext,
+      scores: primaryPage.scores,
+      composite,
+      timestamp: new Date().toISOString(),
+      pages: allPageResults,
+      checkpoints: hasCheckpoints ? checkpoints : undefined,
+      durationMs: caseDuration,
+      log: harnessLogs.join('\n') || undefined,
+    };
+
+    results.push(result);
+
+    // Write individual result
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const resultPath = join(resultsDir, `${testCase.id}-${harness.name}-${ts}.json`);
+    writeFileSync(resultPath, JSON.stringify(result, null, 2));
+    log.log(`Result written to ${resultPath}`);
+
+    log.log(`Model: ${resolvedModel ?? options.model ?? 'default'}`);
+    log.log(`Composite: ${composite} (${formatDuration(caseDuration)})`);
+    for (const pr of allPageResults) {
+      log.log(`  ${pr.role}: ${pr.title} → ${pr.composite.toFixed(3)}`);
+    }
+  }
+
+  return results;
+}
+
+export async function runE2E(options: E2EOptions): Promise<EvalResult[]> {
+  const fixturesDir = options.fixturesDir ?? join(resolve('.'), 'fixtures');
+  const resultsDir = options.resultsDir ?? join(resolve('.'), 'results');
+  mkdirSync(resultsDir, { recursive: true });
+
+  const log = createLogger(resultsDir);
+  log.log(`Log file: ${log.path}`);
+  log.log(`Suite: ${options.suite}, Harness: ${options.harness}, Model: ${options.model ?? 'default'}`);
+
+  const harness = getHarness(options.harness, options.model);
+  let cases = loadTestCases(fixturesDir, options.suite);
+  if (options.caseFilter) {
+    cases = cases.filter((c) => c.testCase.id === options.caseFilter);
+    if (cases.length === 0) {
+      throw new Error(`No test case found with id "${options.caseFilter}"`);
+    }
+  }
+  log.log(`Loaded ${cases.length} test case(s)`);
+
+  // External wiki: use the user's existing wai config and process env
+  if (options.externalWiki) {
+    log.log('Using external wiki (existing wai credentials)');
+    const env: Record<string, string | undefined> = { ...process.env };
+    return runCases(cases, harness, env, options, resultsDir, log);
+  }
+
+  // Isolated wiki: spin up a fresh instance
+  const port = parseInt(process.env['WIKI_PORT'] ?? '8081', 10);
+  log.log(`Starting isolated wiki on port ${port}`);
+  const wiki = await startWiki(port);
+  log.log(`Wiki ready at ${wiki.url} (data: ${wiki.dataPath})`);
+
+  try {
+    configureWaiCredentials(wiki);
+    const env: Record<string, string | undefined> = { ...process.env, ...wiki.env };
+    return await runCases(cases, harness, env, options, resultsDir, log);
+  } finally {
+    if (options.inspect) {
+      log.log(`Inspect mode: wiki running at ${wiki.url}`);
+      await waitForEnter(`\n==> Wiki is running at ${wiki.url}\n    Press Enter to tear down and exit...`);
+    }
+    log.log('Tearing down wiki');
+    wiki.destroy();
+  }
+}

--- a/evals/src/runner/grade.ts
+++ b/evals/src/runner/grade.ts
@@ -1,0 +1,325 @@
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, resolve, basename, isAbsolute } from 'node:path';
+import type { TestCase, EvalResult, PageResult, PageRole, ContentWeights } from '../types.js';
+import { runGraders, computeComposite, type GraderOptions } from '../graders/index.js';
+
+export interface GradeOptions extends GraderOptions {
+  /** Path to wikitext file to grade (single page mode). */
+  page?: string;
+  /** Path to directory of wikitext files (multi-page mode). */
+  pages?: string;
+  /** Path to a previous result JSON to re-grade. */
+  result?: string;
+  /** Directory to write results. Defaults to evals/results/. */
+  resultsDir?: string;
+  /** Path to vault for citation-based accuracy verification. */
+  vaultPath?: string;
+  /** Run only these graders and merge with existing scores from the previous result. */
+  graders?: string[];
+}
+
+function loadSourceData(fixtureDir: string, testCase: TestCase): string {
+  const sourceParts: string[] = [];
+
+  for (const source of testCase.sources) {
+    const sourcePath = isAbsolute(source.path) ? source.path : join(fixtureDir, source.path);
+    if (existsSync(sourcePath)) {
+      try {
+        const content = readFileSync(sourcePath, 'utf-8');
+        sourceParts.push(`=== ${source.type} (${source.snapshotId}) ===\n${content}`);
+      } catch {
+        sourceParts.push(`=== ${source.type} (${source.snapshotId}) ===\n[Could not read]`);
+      }
+    }
+  }
+
+  return sourceParts.join('\n\n');
+}
+
+function classifyFile(filename: string): PageRole {
+  const name = basename(filename, '.wikitext');
+  if (name === 'person') return 'person';
+  if (name === 'project') return 'project';
+  if (name === 'talk') return 'talk';
+  if (name.startsWith('source')) return 'source';
+  return 'episode';
+}
+
+/**
+ * Match a page title against a references map key.
+ * Supports exact match and glob-style prefix match (e.g. "Source:Facebook/*").
+ */
+function matchReferenceKey(pageTitle: string, pattern: string): boolean {
+  if (pattern === pageTitle) return true;
+  if (pattern.endsWith('/*')) {
+    const prefix = pattern.slice(0, -1);
+    return pageTitle.startsWith(prefix) || pageTitle === prefix.slice(0, -1);
+  }
+  return false;
+}
+
+/**
+ * Load reference wikitext for a page from the test case references map
+ * or legacy reference field.
+ */
+function loadReferenceForPage(
+  testCase: TestCase,
+  fixtureDir: string,
+  pageTitle: string,
+  role: PageRole,
+): string | undefined {
+  // 1. Check references map
+  if (testCase.references) {
+    for (const [pattern, refPath] of Object.entries(testCase.references)) {
+      if (matchReferenceKey(pageTitle, pattern)) {
+        const absPath = isAbsolute(refPath) ? refPath : join(fixtureDir, refPath);
+        try {
+          return readFileSync(absPath, 'utf-8');
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  // 2. Backward compat: testCase.reference for person role
+  if (role === 'person' && testCase.reference) {
+    const refPath = isAbsolute(testCase.reference) ? testCase.reference : join(fixtureDir, testCase.reference);
+    try {
+      return readFileSync(refPath, 'utf-8');
+    } catch {
+      return undefined;
+    }
+  }
+
+  // 3. Implicit reference.wikitext in fixture dir for person role
+  if (role === 'person') {
+    const implicitPath = join(fixtureDir, 'reference.wikitext');
+    if (existsSync(implicitPath)) {
+      try {
+        return readFileSync(implicitPath, 'utf-8');
+      } catch {
+        return undefined;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function loadPageFiles(pagesDir: string): { filename: string; role: PageRole; wikitext: string }[] {
+  const absDir = resolve(pagesDir);
+  const files = readdirSync(absDir).filter((f) => f.endsWith('.wikitext'));
+  return files.map((f) => ({
+    filename: f,
+    role: classifyFile(f),
+    wikitext: readFileSync(join(absDir, f), 'utf-8'),
+  }));
+}
+
+function computeWeightedComposite(pageResults: PageResult[], hasExpectedEpisodes: boolean, weights?: ContentWeights): number {
+  const person = pageResults.find((p) => p.role === 'person') ?? pageResults.find((p) => p.role === 'project');
+  const episodes = pageResults.filter((p) => p.role === 'episode');
+  const talk = pageResults.find((p) => p.role === 'talk');
+
+  let primaryWeight: number;
+  let episodeWeight: number;
+  let talkWeight: number;
+
+  if (weights) {
+    primaryWeight = weights.primary;
+    episodeWeight = weights.episodes;
+    talkWeight = weights.talk;
+  } else if (hasExpectedEpisodes || episodes.length > 0) {
+    primaryWeight = 0.5;
+    episodeWeight = 0.4;
+    talkWeight = 0.1;
+  } else {
+    primaryWeight = 0.85;
+    episodeWeight = 0;
+    talkWeight = 0.15;
+  }
+
+  if (!talk) {
+    primaryWeight += talkWeight;
+    talkWeight = 0;
+  }
+
+  const primary = person ?? (episodes.length > 0 ? episodes[0] : undefined);
+  const extraEpisodes = person ? episodes : episodes.slice(1);
+
+  let weighted = 0;
+  if (primary) weighted += primary.composite * primaryWeight;
+  if (extraEpisodes.length > 0) {
+    const avgEpisode = extraEpisodes.reduce((sum, e) => sum + e.composite, 0) / extraEpisodes.length;
+    weighted += avgEpisode * episodeWeight;
+  }
+  if (talk) weighted += talk.composite * talkWeight;
+
+  return Math.round(weighted * 1000) / 1000;
+}
+
+export async function gradeFixture(
+  fixtureDir: string,
+  options: GradeOptions,
+): Promise<EvalResult> {
+  const absDir = resolve(fixtureDir);
+
+  // Load test case
+  const caseJson = readFileSync(join(absDir, 'case.json'), 'utf-8');
+  const testCase: TestCase = JSON.parse(caseJson);
+
+  // Load source data
+  const sourceData = loadSourceData(absDir, testCase);
+
+  const subject = testCase.subject ?? testCase.id;
+  const vault = options.vaultPath ? { vaultPath: options.vaultPath } : options.vault;
+
+  // Re-grade from previous result JSON
+  if (options.result) {
+    const prevJson = readFileSync(resolve(options.result), 'utf-8');
+    const prev: EvalResult = JSON.parse(prevJson);
+    const prevPages = prev.pages ?? [{ title: subject, role: 'person' as PageRole, wikitext: prev.output, scores: [], composite: 0 }];
+    const graderFilter = options.graders;
+    const pageResults: PageResult[] = [];
+
+    for (const pp of prevPages) {
+      const referenceWikitext = loadReferenceForPage(testCase, absDir, pp.title, pp.role);
+      const newScores = await runGraders(pp.wikitext, testCase, sourceData, {
+        ...options,
+        role: pp.role,
+        subject,
+        expectedEpisodes: testCase.expectedEpisodes,
+        referenceWikitext,
+        vault,
+        log: prev.log,
+        graderFilter,
+      });
+
+      // When filtering, merge new scores into existing ones from the previous result
+      let scores: typeof newScores;
+      if (graderFilter) {
+        const newGraderNames = new Set(newScores.map((s) => s.grader));
+        const kept = pp.scores.filter((s) => !newGraderNames.has(s.grader));
+        scores = [...kept, ...newScores];
+      } else {
+        scores = newScores;
+      }
+
+      const composite = computeComposite(scores);
+      pageResults.push({ title: pp.title, role: pp.role, wikitext: pp.wikitext, scores, composite });
+    }
+
+    const hasExpectedEpisodes = (testCase.expectedEpisodes?.length ?? 0) > 0;
+    const primaryPage = pageResults.find((p) => p.role === 'person') ?? pageResults.find((p) => p.role === 'project') ?? pageResults[0];
+    const composite = pageResults.length === 1
+      ? pageResults[0].composite
+      : computeWeightedComposite(pageResults, hasExpectedEpisodes, testCase.weights);
+
+    const result: EvalResult = {
+      caseId: testCase.id,
+      suite: testCase.suite,
+      harness: prev.harness,
+      model: prev.model,
+      output: primaryPage.wikitext,
+      scores: primaryPage.scores,
+      composite,
+      timestamp: new Date().toISOString(),
+      pages: pageResults,
+      log: prev.log,
+    };
+
+    const resultsDir = options.resultsDir ?? join(absDir, '..', '..', '..', 'results');
+    mkdirSync(resultsDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const resultPath = join(resultsDir, `${testCase.id}-${ts}.json`);
+    writeFileSync(resultPath, JSON.stringify(result, null, 2));
+
+    return result;
+  }
+
+  // Multi-page mode
+  if (options.pages) {
+    const pageFiles = loadPageFiles(options.pages);
+    const pageResults: PageResult[] = [];
+
+    for (const pf of pageFiles) {
+      const title = basename(pf.filename, '.wikitext');
+      const referenceWikitext = loadReferenceForPage(testCase, absDir, title, pf.role);
+      const scores = await runGraders(pf.wikitext, testCase, sourceData, {
+        ...options,
+        role: pf.role,
+        subject,
+        expectedEpisodes: testCase.expectedEpisodes,
+        referenceWikitext,
+        vault,
+      });
+      const composite = computeComposite(scores);
+      pageResults.push({ title, role: pf.role, wikitext: pf.wikitext, scores, composite });
+    }
+
+    const hasExpectedEpisodes = (testCase.expectedEpisodes?.length ?? 0) > 0;
+    const primaryPage = pageResults.find((p) => p.role === 'person') ?? pageResults.find((p) => p.role === 'project') ?? pageResults[0];
+    const composite = pageResults.length === 1
+      ? pageResults[0].composite
+      : computeWeightedComposite(pageResults, hasExpectedEpisodes, testCase.weights);
+
+    const result: EvalResult = {
+      caseId: testCase.id,
+      suite: testCase.suite,
+      harness: 'manual',
+      model: 'n/a',
+      output: primaryPage.wikitext,
+      scores: primaryPage.scores,
+      composite,
+      timestamp: new Date().toISOString(),
+      pages: pageResults,
+    };
+
+    const resultsDir = options.resultsDir ?? join(absDir, '..', '..', '..', 'results');
+    mkdirSync(resultsDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const resultPath = join(resultsDir, `${testCase.id}-${ts}.json`);
+    writeFileSync(resultPath, JSON.stringify(result, null, 2));
+
+    return result;
+  }
+
+  // Single page mode (backward compatible)
+  if (!options.page) {
+    throw new Error('Either --page, --pages, or --result is required');
+  }
+
+  const wikitext = readFileSync(resolve(options.page), 'utf-8');
+
+  // Try to load reference for single-page mode
+  const role = options.role ?? 'person';
+  const referenceWikitext = loadReferenceForPage(testCase, absDir, subject, role);
+
+  const scores = await runGraders(wikitext, testCase, sourceData, {
+    ...options,
+    referenceWikitext,
+    vault,
+  });
+  const composite = computeComposite(scores);
+
+  const result: EvalResult = {
+    caseId: testCase.id,
+    suite: testCase.suite,
+    harness: 'manual',
+    model: 'n/a',
+    output: wikitext,
+    scores,
+    composite,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Write results
+  const resultsDir = options.resultsDir ?? join(absDir, '..', '..', '..', 'results');
+  mkdirSync(resultsDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const resultPath = join(resultsDir, `${testCase.id}-${ts}.json`);
+  writeFileSync(resultPath, JSON.stringify(result, null, 2));
+
+  return result;
+}

--- a/evals/src/types.ts
+++ b/evals/src/types.ts
@@ -1,0 +1,125 @@
+export interface TestCase {
+  id: string;
+  suite: 'incremental';
+  description: string;
+  pageType: 'Person' | 'Episode' | 'Project';
+  sources: SourceRef[];
+  reference?: string;
+  turns?: FeedbackTurn[];
+  expectedCrossRefs?: number;
+  /** Expected primary page title */
+  subject?: string;
+  /** Episode page titles the reference solution includes */
+  expectedEpisodes?: string[];
+  /** Map of page title (or glob like Source:whatsapp/*) to reference wikitext file path relative to fixture dir */
+  references?: Record<string, string>;
+  /** Minimum checkpoint 1 composite to proceed to checkpoint 2 (default 0.7) */
+  checkpointThreshold?: number;
+  /** Incremental checkpoint specifications (used by suite: 'incremental') */
+  checkpoints?: CheckpointSpec[];
+  /** Content page weights for composite scoring. Source pages always use a separate 20/80 split. */
+  weights?: ContentWeights;
+}
+
+export interface ContentWeights {
+  /** Weight for the primary content page (person or episode). Default: 0.85 (no episodes) or 0.5 (with episodes). */
+  primary: number;
+  /** Weight for episode pages. Default: 0 (no episodes) or 0.4 (with episodes). */
+  episodes: number;
+  /** Weight for the talk page. Default: 0.15 (no episodes) or 0.1 (with episodes). */
+  talk: number;
+  /** Fraction of overall composite from source pages (rest goes to content). Default: 0.2. */
+  source?: number;
+}
+
+export interface GradeTarget {
+  /** Page title pattern, e.g. "Source:Instagram/*", "Alex Chen", "Talk:Alex Chen" */
+  pattern: string;
+  /** Determines which graders run against matched pages */
+  role: PageRole;
+}
+
+export interface CheckpointSpec {
+  /** Checkpoint identifier, e.g. "inventory", "survey", "skeleton" */
+  id: string;
+  /** Task description given to the agent for this checkpoint */
+  description: string;
+  /** New sources to introduce at this checkpoint */
+  sources?: SourceRef[];
+  /** Pages to grade after this checkpoint completes */
+  grade: GradeTarget[];
+  /** Optional gate score — stop the run if the checkpoint composite is below this */
+  threshold?: number;
+  /** If true, look for a citation manifest uploaded by the agent and use it for accuracy grading */
+  produceManifest?: boolean;
+  /** Path to owner anecdotes JSON file (relative to fixture dir) */
+  ownerInput?: string;
+  /** Skip the reference grader for this checkpoint (unfair when not all sources available) */
+  skipReference?: boolean;
+}
+
+export type PageRole = 'person' | 'episode' | 'project' | 'talk' | 'source';
+
+export interface PageResult {
+  title: string;
+  role: PageRole;
+  wikitext: string;
+  scores: GraderResult[];
+  composite: number;
+}
+
+export interface SourceRef {
+  path: string;
+  type: string;
+  snapshotId: string;
+}
+
+export interface FeedbackTurn {
+  feedback: string;
+}
+
+export interface GraderResult {
+  grader: string;
+  score: number;
+  skipped?: boolean;
+  details: GraderCheck[];
+}
+
+export interface GraderCheck {
+  check: string;
+  passed: boolean;
+  penalty: number;
+  note?: string;
+}
+
+export interface CheckpointResult {
+  checkpoint: number;
+  stage: string;
+  pages: PageResult[];
+  composite: number;
+  passed: boolean;
+  threshold: number;
+  /** Wall-clock duration of this checkpoint in milliseconds */
+  durationMs?: number;
+}
+
+export interface EvalResult {
+  caseId: string;
+  suite: string;
+  harness: string;
+  model: string;
+  /** Primary page wikitext (backward compat) */
+  output: string;
+  /** Primary page scores (backward compat) */
+  scores: GraderResult[];
+  composite: number;
+  timestamp: string;
+  /** Per-page breakdown when multi-page grading is used */
+  pages?: PageResult[];
+  /** Checkpoint results when checkpoint grading is used */
+  checkpoints?: CheckpointResult[];
+  /** Wall-clock duration of the full eval run in milliseconds */
+  durationMs?: number;
+  /** Agent session transcript / tool call log */
+  log?: string;
+}

--- a/evals/src/vault.ts
+++ b/evals/src/vault.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ManifestFile {
+  path: string;
+  hash: string;
+}
+
+export interface Manifest {
+  files: ManifestFile[];
+}
+
+/**
+ * Read a snapshot manifest from the vault.
+ * Returns null if the manifest doesn't exist or can't be parsed.
+ */
+export function readManifest(vaultPath: string, snapshotId: string): Manifest | null {
+  try {
+    const raw = readFileSync(join(vaultPath, 'snapshots', `${snapshotId}.json`), 'utf-8');
+    return JSON.parse(raw) as Manifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a raw object from the vault by its hash.
+ * Objects are stored at objects/<2-char prefix>/<full hash>.
+ */
+export function readObject(vaultPath: string, hash: string): Buffer | null {
+  const prefix = hash.slice(0, 2);
+  try {
+    return readFileSync(join(vaultPath, 'objects', prefix, hash));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the first file in a manifest whose path matches a predicate.
+ */
+export function findInManifest(
+  manifest: Manifest,
+  predicate: (path: string) => boolean,
+): ManifestFile | undefined {
+  return manifest.files.find((f) => predicate(f.path));
+}
+
+/**
+ * Find all files in a manifest whose path matches a predicate.
+ */
+export function findAllInManifest(
+  manifest: Manifest,
+  predicate: (path: string) => boolean,
+): ManifestFile[] {
+  return manifest.files.filter((f) => predicate(f.path));
+}
+
+interface InstagramMessage {
+  sender_name: string;
+  timestamp_ms: number;
+  content?: string;
+  photos?: { uri: string }[];
+  videos?: { uri: string }[];
+  audio_files?: { uri: string }[];
+}
+
+interface InstagramThread {
+  participants: { name: string }[];
+  messages: InstagramMessage[];
+}
+
+/**
+ * Parse a date string which may be a single date or a range (start/end).
+ * Returns { minTime, maxTime } in epoch milliseconds.
+ *
+ * Supported formats:
+ * - "2019-11-14" (single date, +-windowDays)
+ * - "2019-11-01/2020-02-07" (date range, used directly)
+ * - "2019-11/2020-02" (month range, expanded to full range)
+ */
+function parseDateRange(dateStr: string, windowDays: number): { minTime: number; maxTime: number } | null {
+  if (dateStr.includes('/')) {
+    const [startStr, endStr] = dateStr.split('/');
+
+    // Expand month-only strings: "2019-11" -> "2019-11-01"
+    const expandDate = (s: string, end: boolean) => {
+      if (/^\d{4}-\d{2}$/.test(s)) {
+        if (end) {
+          // Last day of month
+          const [year, month] = s.split('-').map(Number);
+          const lastDay = new Date(year, month, 0).getDate();
+          return `${s}-${String(lastDay).padStart(2, '0')}`;
+        }
+        return `${s}-01`;
+      }
+      return s;
+    };
+
+    const start = new Date(expandDate(startStr, false));
+    const end = new Date(expandDate(endStr, true));
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return null;
+    return { minTime: start.getTime(), maxTime: end.getTime() + 24 * 60 * 60 * 1000 - 1 };
+  }
+
+  const target = new Date(dateStr);
+  if (isNaN(target.getTime())) return null;
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  return { minTime: target.getTime() - windowMs, maxTime: target.getTime() + windowMs };
+}
+
+/**
+ * Parse Instagram message JSON and extract messages within a date window.
+ * Returns formatted text with sender, date, and content.
+ * Caps at 50 messages to keep context manageable.
+ *
+ * Supports single dates ("2019-11-14") and date ranges ("2019-11-01/2020-02-07").
+ */
+export function extractMessagesNearDate(
+  json: string,
+  targetDate: string,
+  windowDays: number = 1,
+): string {
+  let thread: InstagramThread;
+  try {
+    thread = JSON.parse(json) as InstagramThread;
+  } catch {
+    return '';
+  }
+
+  if (!thread.messages || !Array.isArray(thread.messages)) {
+    return '';
+  }
+
+  const range = parseDateRange(targetDate, windowDays);
+  if (!range) return '';
+
+  const { minTime, maxTime } = range;
+
+  const filtered = thread.messages
+    .filter((m) => m.timestamp_ms >= minTime && m.timestamp_ms <= maxTime)
+    .sort((a, b) => a.timestamp_ms - b.timestamp_ms)
+    .slice(0, 50);
+
+  if (filtered.length === 0) {
+    return '';
+  }
+
+  const lines = filtered.map((m) => {
+    const date = new Date(m.timestamp_ms).toISOString().slice(0, 19).replace('T', ' ');
+    const content = m.content ?? '[media]';
+    return `[${date}] ${m.sender_name}: ${content}`;
+  });
+
+  const participants = thread.participants?.map((p) => p.name).join(', ') ?? 'unknown';
+  return `Thread participants: ${participants}\n\n${lines.join('\n')}`;
+}

--- a/evals/src/wiki.ts
+++ b/evals/src/wiki.ts
@@ -1,0 +1,308 @@
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import http from 'node:http';
+
+const HEALTH_POLL_MS = 200;
+const HEALTH_TIMEOUT_MS = 30_000;
+
+const DESKTOP_ROOT = resolve(import.meta.dirname ?? '.', '..', '..', 'desktop');
+const RESOURCES = join(DESKTOP_ROOT, 'resources');
+const PHP_PATH = join(RESOURCES, 'php', 'bin', 'php');
+const LUA_PATH = join(RESOURCES, 'lua', 'bin', 'lua');
+const MW_PATH = join(RESOURCES, 'mediawiki');
+const TEMPLATES_PATH = join(RESOURCES, 'templates');
+
+export interface WikiInstance {
+  url: string;
+  port: number;
+  dataPath: string;
+  vaultPath: string;
+  username: string;
+  password: string;
+  /** Environment variables to pass to wai and harness processes */
+  env: Record<string, string>;
+  stop: () => void;
+  destroy: () => void;
+}
+
+function generateSecretKey(): string {
+  return randomBytes(32).toString('hex');
+}
+
+function generateLocalSettings(opts: {
+  dataPath: string;
+  serverUrl: string;
+  resourcesPath: string;
+}): string {
+  return [
+    '<?php',
+    '',
+    `$wgSecretKey = "${generateSecretKey()}";`,
+    `$wgUpgradeKey = "${generateSecretKey().slice(0, 16)}";`,
+    '',
+    '## Core',
+    '$wgSitename = "Whoami Wiki";',
+    `$wgServer = "${opts.serverUrl}";`,
+    '$wgScriptPath = "";',
+    '$wgArticlePath = "/wiki/$1";',
+    '',
+    '## Database (SQLite)',
+    '$wgDBtype = "sqlite";',
+    '$wgDBname = "wiki";',
+    `$wgSQLiteDataDir = "${opts.dataPath}";`,
+    '',
+    '## Paths',
+    `$wgUploadDirectory = "${opts.dataPath}/images";`,
+    '$wgUploadPath = "/images";',
+    `$wgCacheDirectory = "${opts.dataPath}/cache";`,
+    '',
+    '## Security',
+    "$wgGroupPermissions['*']['createaccount'] = false;",
+    "$wgGroupPermissions['*']['edit'] = false;",
+    "$wgGroupPermissions['*']['read'] = true;",
+    '',
+    '## Error handling',
+    'error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );',
+    "ini_set( 'display_errors', '0' );",
+    '',
+    '## Locale',
+    '$wgLanguageCode = "en";',
+    '$wgLocaltimezone = "UTC";',
+    '',
+    '## Uploads',
+    '$wgEnableUploads = true;',
+    '$wgUseImageMagick = false;',
+    "$wgFileExtensions = array_merge( $wgFileExtensions, [ 'mp3', 'mp4', 'ogg', 'ogv', 'opus', 'wav', 'webm', 'flac' ] );",
+    "ini_set( 'upload_max_filesize', '50M' );",
+    "ini_set( 'post_max_size', '55M' );",
+    '$wgMaxUploadSize = 1024 * 1024 * 50;',
+    '$wgVerifyMimeType = false;',
+    '',
+    '## Skin',
+    "wfLoadSkin( 'Vector' );",
+    '$wgDefaultSkin = "vector-2022";',
+    '',
+    '## Extensions',
+    "wfLoadExtension( 'Cite' );",
+    "wfLoadExtension( 'CiteThisPage' );",
+    "wfLoadExtension( 'ParserFunctions' );",
+    "wfLoadExtension( 'Scribunto' );",
+    "wfLoadExtension( 'TemplateData' );",
+    "wfLoadExtension( 'TemplateStyles' );",
+    ...(existsSync(join(opts.resourcesPath, 'mediawiki', 'extensions', 'TimedMediaHandler', 'extension.json')) ? [
+      "wfLoadExtension( 'TimedMediaHandler' );",
+      '',
+      '## TimedMediaHandler',
+      '$wgTmhEnableTranscoding = false;',
+      "$wgTmhFileExtensions = [ 'mp3', 'mp4', 'ogg', 'ogv', 'opus', 'wav', 'webm', 'flac' ];",
+      `$wgFFmpegLocation = '${opts.resourcesPath}/ffmpeg/bin/ffmpeg';`,
+      '$wgMaxShellMemory = 0;',
+    ] : []),
+    '',
+    '## Scribunto',
+    "$wgScribuntoDefaultEngine = 'luastandalone';",
+    `$wgScribuntoEngineConf['luastandalone']['luaPath'] = '${LUA_PATH}';`,
+    '',
+    '## Source namespace (100/101)',
+    'define("NS_SOURCE", 100);',
+    'define("NS_SOURCE_TALK", 101);',
+    '$wgExtraNamespaces[NS_SOURCE] = "Source";',
+    '$wgExtraNamespaces[NS_SOURCE_TALK] = "Source_talk";',
+    '',
+    '## Task namespace (102/103)',
+    'define("NS_TASK", 102);',
+    'define("NS_TASK_TALK", 103);',
+    '$wgExtraNamespaces[NS_TASK] = "Task";',
+    '$wgExtraNamespaces[NS_TASK_TALK] = "Task_talk";',
+    '',
+    '## Short URLs',
+    '$wgUsePathInfo = true;',
+    '',
+    '## Performance',
+    '$wgMainCacheType = CACHE_NONE;',
+    '$wgCachePages = false;',
+    '',
+    '## Job queue (run inline)',
+    '$wgJobRunRate = 1;',
+    '',
+  ].join('\n');
+}
+
+function runPhp(args: string[], cwd?: string): string {
+  return execFileSync(PHP_PATH, [
+    '-d', 'display_errors=Off',
+    '-d', 'error_reporting=22527',
+    ...args,
+  ], {
+    cwd: cwd ?? MW_PATH,
+    encoding: 'utf-8',
+    timeout: 120_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+function waitForServer(url: string): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (Date.now() - start > HEALTH_TIMEOUT_MS) {
+        reject(new Error('Wiki server failed to start within timeout'));
+        return;
+      }
+
+      const req = http.get(`${url}/api.php?action=query&meta=siteinfo&format=json`, (res) => {
+        if (res.statusCode === 200) {
+          res.resume();
+          resolve();
+        } else {
+          res.resume();
+          setTimeout(check, HEALTH_POLL_MS);
+        }
+      });
+      req.on('error', () => {
+        setTimeout(check, HEALTH_POLL_MS);
+      });
+      req.end();
+    };
+    check();
+  });
+}
+
+function importPage(confPath: string, title: string, filePath: string): void {
+  const content = readFileSync(filePath, 'utf-8');
+  writePageDirect(confPath, title, content);
+}
+
+/**
+ * Write a wiki page directly via PHP maintenance script, bypassing HTTP.
+ * Much faster and more reliable than `wai write` for bulk operations.
+ */
+export function writePageDirect(confPath: string, title: string, content: string): void {
+  execFileSync(PHP_PATH, [
+    '-d', 'display_errors=Off',
+    '-d', 'error_reporting=22527',
+    'maintenance/run.php', 'edit',
+    '--conf', confPath,
+    title,
+  ], {
+    cwd: MW_PATH,
+    input: content,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+/**
+ * Spin up an isolated MediaWiki instance using the desktop app's bundled resources.
+ * Creates a temp data directory, installs the DB, imports templates, and starts
+ * PHP's built-in server on the given port.
+ */
+export async function startWiki(port: number): Promise<WikiInstance> {
+  // Verify desktop resources exist
+  if (!existsSync(PHP_PATH)) {
+    throw new Error(
+      `PHP not found at ${PHP_PATH}. Run desktop/scripts/build-php.sh first.`,
+    );
+  }
+  if (!existsSync(join(MW_PATH, 'index.php'))) {
+    throw new Error(
+      `MediaWiki not found at ${MW_PATH}. Run desktop/scripts/bundle-mediawiki.sh first.`,
+    );
+  }
+
+  const username = 'Admin';
+  const password = 'evalpass1234';
+  const serverUrl = `http://127.0.0.1:${port}`;
+
+  // Create temp data + vault directories
+  const basePath = join(tmpdir(), `whoami-eval-${randomBytes(6).toString('hex')}`);
+  const dataPath = join(basePath, 'data');
+  const vaultPath = join(basePath, 'vault');
+  mkdirSync(dataPath, { recursive: true });
+  mkdirSync(join(dataPath, 'images'), { recursive: true });
+  mkdirSync(join(dataPath, 'cache'), { recursive: true });
+  mkdirSync(vaultPath, { recursive: true });
+
+  console.log(`==> Provisioning wiki at ${serverUrl} (root: ${basePath})`);
+
+  // Install MediaWiki
+  runPhp([
+    'maintenance/run.php', 'install',
+    '--dbtype', 'sqlite',
+    '--dbpath', dataPath,
+    '--dbname', 'wiki',
+    '--scriptpath', '',
+    '--pass', password,
+    '--server', serverUrl,
+    'Whoami Wiki', username,
+  ]);
+
+  // Remove installer-generated LocalSettings.php from MW dir
+  const mwLocalSettings = join(MW_PATH, 'LocalSettings.php');
+  if (existsSync(mwLocalSettings)) {
+    rmSync(mwLocalSettings);
+  }
+
+  // Write our LocalSettings.php
+  const confPath = join(dataPath, 'LocalSettings.php');
+  writeFileSync(confPath, generateLocalSettings({
+    dataPath,
+    serverUrl,
+    resourcesPath: RESOURCES,
+  }));
+
+  // Run database update for extensions
+  runPhp(['maintenance/run.php', 'update', '--quick', '--conf', confPath]);
+
+  // Import templates
+  importPage(confPath, 'Template:Gap', join(TEMPLATES_PATH, 'Gap.wiki'));
+  importPage(confPath, 'Template:Dialogue', join(TEMPLATES_PATH, 'Dialogue.wiki'));
+  importPage(confPath, 'Template:Infobox person', join(TEMPLATES_PATH, 'Infobox_person.wiki'));
+  importPage(confPath, 'MediaWiki:Common.css', join(TEMPLATES_PATH, 'infobox-styles.css'));
+
+  // Start PHP built-in server
+  const proc: ChildProcess = spawn(PHP_PATH, [
+    '-d', 'display_errors=Off',
+    '-d', 'error_reporting=22527',
+    '-S', `127.0.0.1:${port}`,
+    '-t', MW_PATH,
+    join(MW_PATH, 'router.php'),
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, MW_DATA_PATH: dataPath },
+  });
+
+  proc.stdout?.on('data', () => {});
+  proc.stderr?.on('data', () => {});
+
+  await waitForServer(serverUrl);
+  console.log(`==> Wiki ready at ${serverUrl}`);
+
+  const env: Record<string, string> = {
+    WIKI_SERVER: serverUrl,
+    WAI_VAULT_PATH: vaultPath,
+    WIKI_DATA_PATH: dataPath,
+  };
+
+  return {
+    url: serverUrl,
+    port,
+    dataPath,
+    vaultPath,
+    username,
+    password,
+    env,
+    stop() {
+      proc.kill('SIGTERM');
+    },
+    destroy() {
+      proc.kill('SIGTERM');
+      rmSync(basePath, { recursive: true, force: true });
+      console.log(`==> Wiki torn down (${basePath} removed)`);
+    },
+  };
+}

--- a/evals/test/citations.test.ts
+++ b/evals/test/citations.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { gradeCitations, parseCitations, findUncitedClaims } from '../src/graders/citations.js';
+
+describe('parseCitations', () => {
+  it('parses a valid photo citation', () => {
+    const wikitext = '{{Cite photo | hash = abc123 | date = 2024-03-15 | snapshot = snap1}}';
+    const citations = parseCitations(wikitext);
+    assert.equal(citations.length, 1);
+    assert.equal(citations[0].template, 'photo');
+    assert.equal(citations[0].fields['hash'], 'abc123');
+    assert.equal(citations[0].fields['date'], '2024-03-15');
+  });
+
+  it('parses a valid message citation', () => {
+    const wikitext = '{{Cite message | hash = def456 | date = 2024-01-01 | author = Alice}}';
+    const citations = parseCitations(wikitext);
+    assert.equal(citations.length, 1);
+    assert.equal(citations[0].template, 'message');
+    assert.equal(citations[0].fields['author'], 'Alice');
+  });
+
+  it('parses multiple citations', () => {
+    const wikitext = `Text {{Cite photo | hash = a | date = 2024-01-01}} more text {{Cite message | hash = b | date = 2024-02-01 | author = Bob}}`;
+    const citations = parseCitations(wikitext);
+    assert.equal(citations.length, 2);
+  });
+
+  it('returns empty array for no citations', () => {
+    const citations = parseCitations('Just some text with no citations.');
+    assert.equal(citations.length, 0);
+  });
+});
+
+describe('findUncitedClaims', () => {
+  it('finds uncited factual sentences', () => {
+    const wikitext = `Jeremy visited Paris in January 2024. He took many photos of the Eiffel Tower.`;
+    const uncited = findUncitedClaims(wikitext);
+    assert.ok(uncited.length > 0);
+  });
+
+  it('ignores sentences with nearby ref tags', () => {
+    const wikitext = `Jeremy visited Paris in January 2024.<ref>{{Cite photo | hash = x | date = 2024-01-01}}</ref>`;
+    const uncited = findUncitedClaims(wikitext);
+    assert.equal(uncited.length, 0);
+  });
+
+  it('ignores headings and templates', () => {
+    const wikitext = `== January 2024 ==\n\n{{Infobox Person | name = Jeremy}}`;
+    const uncited = findUncitedClaims(wikitext);
+    assert.equal(uncited.length, 0);
+  });
+
+  it('ignores file and image embeds', () => {
+    const wikitext = `[[File:Cdmx-2022-03-26-dfw-transit.jpg|thumb|Transit-day photo geotagged near Dallas-Fort Worth, 2022-03-26 16:00.]]`;
+    const uncited = findUncitedClaims(wikitext);
+    assert.equal(uncited.length, 0);
+  });
+});
+
+describe('citations grader', () => {
+  it('scores 1.0 for all valid citations with no uncited claims', () => {
+    const wikitext = `Text.<ref>{{Cite photo | hash = abc | date = 2024-01-01}}</ref> More text.<ref>{{Cite message | hash = def | date = 2024-02-01 | author = Alice}}</ref>`;
+    const result = gradeCitations(wikitext);
+    assert.equal(result.grader, 'citations');
+    assert.equal(result.score, 1);
+  });
+
+  it('scores 0 for no citations', () => {
+    const result = gradeCitations('Just text with no citations at all.');
+    assert.equal(result.score, 0);
+  });
+
+  it('penalizes citations with missing required fields', () => {
+    const wikitext = `{{Cite photo | hash = abc}}`;
+    const result = gradeCitations(wikitext);
+    assert.ok(result.score < 1);
+  });
+
+  it('penalizes unknown template names', () => {
+    const wikitext = `{{Cite unknown | hash = abc | date = 2024-01-01}}`;
+    const result = gradeCitations(wikitext);
+    assert.ok(result.score < 1);
+    const templateCheck = result.details.find((d) => d.check.includes('Template'));
+    assert.ok(templateCheck);
+    assert.equal(templateCheck.passed, false);
+  });
+
+  it('accepts snapshot as alternative to hash', () => {
+    const wikitext = `{{Cite photo | snapshot = snap1 | date = 2024-01-01}}`;
+    const result = gradeCitations(wikitext);
+    assert.equal(result.score, 1);
+  });
+
+  it('penalizes missing type-specific fields', () => {
+    // Voice note without speaker field
+    const wikitext = `{{Cite voice note | hash = abc | date = 2024-01-01}}`;
+    const result = gradeCitations(wikitext);
+    assert.ok(result.score < 1);
+  });
+
+  it('scores 1.0 for message citation without author', () => {
+    // Per spec, Cite message has no author field
+    const wikitext = `{{Cite message | snapshot = snap1 | date = 2024-01-01 | thread = thread_1 | note = test}}`;
+    const result = gradeCitations(wikitext);
+    assert.equal(result.score, 1);
+  });
+
+  it('accepts vault citation with timestamp instead of date', () => {
+    const wikitext = `{{Cite vault | type = messages | snapshot = snap1 | timestamp = 2021-03-01/2022-05-15 | note = DM thread}}`;
+    const result = gradeCitations(wikitext);
+    assert.equal(result.score, 1);
+  });
+
+  it('handles mixed valid and invalid citations', () => {
+    const wikitext = `{{Cite photo | hash = abc | date = 2024-01-01}} {{Cite badtype | hash = def | date = 2024-02-01}}`;
+    const result = gradeCitations(wikitext);
+    assert.equal(result.score, 0.5);
+  });
+});

--- a/evals/test/completeness.test.ts
+++ b/evals/test/completeness.test.ts
@@ -1,0 +1,410 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { gradeCompleteness } from '../src/graders/completeness.js';
+
+// Total weight for person checks: structural (5.5) + depth (10) + richness (3) + link (0.5) = 19
+const TOTAL_PERSON_WEIGHT = 19;
+
+const FULL_PAGE = `{{Infobox Person
+| name = Test Person
+| birth_date = 1995-06-22
+| birth_place = Denver
+| occupation = Graphic designer
+| known_for = Longest DM thread
+}}
+
+'''Test Person''' (born 22 June 1995 in Denver) is a graphic designer and photography enthusiast documented in the personal archive. She grew up in the Highlands neighbourhood, attended Westlake Academy, and completed a BFA in Graphic Design at Metro College before spending a year travelling through Southeast Asia.
+
+[[File:Test_Person_photo.jpg|thumb|right|250px|Test Person in September 2025.]]
+
+== Background ==
+
+Test Person was born in Denver and raised in the Highlands neighbourhood. Her family has a strong academic background with several relatives in education. Her father teaches at a local community college and her mother runs a small ceramics studio from their garage. The family is close-knit and creative. She tells her parents about her projects and discusses her friends' work with them. Growing up she was passionate about drawing and began formal art classes at age nine, continuing for six years before shifting focus to digital design.
+
+=== Education ===
+
+She attended Westlake Academy in the Highlands for schooling. She initially intended to study architecture but changed direction after a summer workshop in typography convinced her that graphic design was a better fit. She subsequently enrolled at Metro College completing a BFA in Graphic Design.
+
+{{Blockquote|I was sitting in this architecture lecture about load-bearing walls and I just knew this wasn't for me. I walked out and signed up for the typography elective the same afternoon.|Test Person, 14 March 2022}}
+
+=== Career ===
+
+After completing a photography workshop in Portland in August 2022 she began freelancing as a graphic designer while selling prints at local markets. She took on both branding projects and editorial illustration commissions. She also volunteered with a nonprofit teaching digital literacy workshops at a community centre in her neighbourhood.
+
+== Connection with wiki owner ==
+
+The wiki owner befriended Test Person over Instagram DMs in late 2022. They connected over design, bonded over shared musical taste, and met in person before the friendship evolved through several distinct phases over three months of intensive messaging.
+
+=== Phase 1: Design exchange ===
+
+Contact was initiated on 1 March 2022 with a message complimenting a recent poster design.<ref name="ig-2022-03-01">{{Cite message|snapshot=a1b2c3d4|date=2022-03-01|thread=test_thread|note=Opening message}}</ref> She responded with enthusiasm and a slow asynchronous exchange began. On 4 March several messages were sent about a local gallery show with zero response and the conversation could easily have died there.
+
+=== Phase 2: Personality explosion ===
+
+The conversation transformed on 5 March with 185 messages in a single session.<ref name="ig-2022-03-05">{{Cite message|snapshot=a1b2c3d4|date=2022-03-05|thread=test_thread|note=First real-time conversation}}</ref> Strong opinions served as a personality litmus test including a heated debate about serif versus sans-serif fonts. By the end of the day they had established nicknames and a running joke about kerning.
+
+=== Phase 3: The hometown discovery ===
+
+The conversation reached over 500 messages on 13 March when they discovered they had both grown up within a few miles of each other.<ref name="ig-2022-03-13">{{Cite message|snapshot=a1b2c3d4|date=2022-03-13|thread=test_thread|note=Hometown discovery}}</ref> References to shared childhood landmarks flooded into the conversation and never left. The rest of the day covered local nostalgia and mutual acquaintances.
+
+=== Phase 4: Deepening ===
+
+They exchanged 2214 messages in five days averaging 443 per day.<ref name="ig-2022-03-15">{{Cite message|snapshot=a1b2c3d4|date=2022-03-15|thread=test_thread|note=Shared Spotify playlist}}</ref> Key milestones included the creation of a shared Spotify playlist on 15 March and the discovery of overlapping music libraries.<ref name="ig-2022-03-21">{{Cite message|snapshot=a1b2c3d4|date=2022-03-21|thread=test_thread|note=First voice note}}</ref> The first voice note arrived on 21 March when she described an upcoming art residency.
+
+{{Audio clip|Test_Person_voice_note.mp4|Test Person, 21 March 2022 — first voice note in the thread.}}
+
+=== Phase 5: The emotional peak ===
+
+Spring break freed the wiki owner from coursework and the conversation hit its volume peak.<ref name="ig-2022-03-27">{{Cite message|snapshot=a1b2c3d4|date=2022-03-27|thread=test_thread|note=First internet friend}}</ref> On 27 March she explicitly acknowledged the friendship's significance. On 29 March they exchanged stories about past creative failures.<ref name="ig-2022-03-29">{{Cite message|snapshot=a1b2c3d4|date=2022-03-29|thread=test_thread|note=Failure stories exchange}}</ref>
+
+=== Phase 6: Decline and meetings ===
+
+The conversation began to taper from its March heights. The first ten days of April averaged 216 messages per day down from the peak of 400 plus.<ref name="ig-2022-04-19">{{Cite message|snapshot=a1b2c3d4|date=2022-04-19|thread=test_thread|note=First meeting}}</ref> Three in-person meetings occurred in April: a coffee on the 19th, a gallery visit on the 20th, and a concert on the 22nd.<ref name="ig-2022-04-20">{{Cite message|snapshot=a1b2c3d4|date=2022-04-20|thread=test_thread|note=Gallery visit}}</ref><ref name="ig-2022-04-22">{{Cite message|snapshot=a1b2c3d4|date=2022-04-22|thread=test_thread|note=Concert}}</ref>
+
+=== Phase 7: Fading out ===
+
+On 3 May a message about collaborating on a project went unanswered for several days.<ref name="ig-2022-05-03">{{Cite message|snapshot=a1b2c3d4|date=2022-05-03|thread=test_thread|note=Unanswered message}}</ref> A reconnection burst on 22 May produced 126 messages before the thread faded to its final message on 7 June 2022.<ref name="ig-2022-05-22">{{Cite message|snapshot=a1b2c3d4|date=2022-05-22|thread=test_thread|note=Reconnection}}</ref>
+
+{{Blockquote|Honestly it has been so much fun talking about design and music. I really value this friendship even if we are both terrible at replying on time.|Test Person, 4 May 2022}}
+
+== Music ==
+
+The conversation began with a design exchange on 1 March but musical taste quickly became a recurring topic. She professed fierce loyalty to Radiohead and Bjork and equally fierce contempt for generic pop playlists. She had a sophisticated taxonomy of genres and could argue for hours about the distinction between shoegaze and dream pop. Her other major recommendation was a small local band whose debut EP she described as essential listening. She was musically eclectic transitioning from electronic to folk during the conversation period admitting she used to dismiss acoustic music but now finds it grounding. A collaborative Spotify playlist was created on 15 March and became a medium for mutual influence with both parties adding songs from their respective genres. When she played the playlist at a dinner party her friends were surprised by the range.
+
+== Inside jokes ==
+
+A running debate about the best local coffee shop became their signature disagreement born from a throwaway comment on 13 March and amplified into a recurring motif used whenever either needed to provoke the other. A score tally tracked who had made the better music recommendation each week with progression from an even score through to a consistent lead that was maintained throughout and used as leverage. The comic sans tease was consistently and dramatically rejected with mock outrage. References to a shared dislike of brutalist architecture became shorthand for aesthetic disagreement. Key recurring phrases included absolutely not and objectively wrong and I will die on this hill. A boundary signal was established on 20 March to pause uncomfortable lines of conversation though it was immediately repurposed as a joke. A persistent bit developed where the wiki owner pretended to be a demanding art director issuing absurd revision requests.
+
+== Conversation statistics ==
+
+{| class="wikitable"
+|-
+! Metric !! Value
+|-
+| Total messages || 10434
+|-
+| Date range || Mar 2022 - Jun 2022
+|}
+
+== References ==
+<references />
+
+== Bibliography ==
+
+{{Cite vault|type=messages|snapshot=a1b2c3d4|timestamp=2022-03-01/2022-06-07|note=Instagram DM thread.}}
+{{Cite vault|type=messages|snapshot=e5f6a7b8|timestamp=2022-04-18/2022-04-22|note=WhatsApp DMs.}}
+
+[[Category:People]]
+`;
+
+describe('completeness grader', () => {
+  it('scores 1.0 for a complete page', () => {
+    const result = gradeCompleteness(FULL_PAGE);
+    assert.equal(result.grader, 'completeness');
+    assert.equal(result.score, 1);
+    assert.ok(result.details.every((d) => d.passed), `Failed checks: ${result.details.filter((d) => !d.passed).map((d) => d.check).join(', ')}`);
+  });
+
+  it('detects missing lead paragraph', () => {
+    const page = `== Section ==\n\nSome content here that is longer than fifty characters to pass the check.`;
+    const result = gradeCompleteness(page);
+    const lead = result.details.find((d) => d.check.includes('Lead paragraph'));
+    assert.ok(lead);
+    assert.equal(lead.passed, false);
+  });
+
+  it('detects missing infobox', () => {
+    const page = `Lead paragraph here.\n\n== Section ==\n\nContent.\n\n== References ==\n\n<references />\n\n== Bibliography ==\n\n* {{Cite vault | snapshot = x}}\n\n[[Category:Test]]`;
+    const result = gradeCompleteness(page);
+    const infobox = result.details.find((d) => d.check.includes('Infobox'));
+    assert.ok(infobox);
+    assert.equal(infobox.passed, false);
+  });
+
+  it('detects missing body section with prose', () => {
+    const page = `{{Infobox Person | name = X}}\n\nLead.\n\n== References ==\n\n<references />\n\n== Bibliography ==\n\n* {{Cite vault | snapshot = x}}\n\n[[Category:Test]]`;
+    const result = gradeCompleteness(page);
+    const body = result.details.find((d) => d.check.includes('Body section'));
+    assert.ok(body);
+    assert.equal(body.passed, false);
+  });
+
+  it('detects missing references section', () => {
+    const page = `{{Infobox Person | name = X}}\n\nLead.\n\n== Life ==\n\nThis is a body section with more than fifty characters of prose content here.\n\n== Bibliography ==\n\n* {{Cite vault | snapshot = x}}\n\n[[Category:Test]]`;
+    const result = gradeCompleteness(page);
+    const refs = result.details.find((d) => d.check.includes('References section'));
+    assert.ok(refs);
+    assert.equal(refs.passed, false);
+  });
+
+  it('detects missing bibliography section', () => {
+    const page = `{{Infobox Person | name = X}}\n\nLead.\n\n== Life ==\n\nThis is a body section with more than fifty characters of prose content here.\n\n== References ==\n\n<references />\n\n[[Category:Test]]`;
+    const result = gradeCompleteness(page);
+    const bib = result.details.find((d) => d.check.includes('Bibliography'));
+    assert.ok(bib);
+    assert.equal(bib.passed, false);
+  });
+
+  it('detects missing category tag', () => {
+    const page = `{{Infobox Person | name = X}}\n\nLead.\n\n== Life ==\n\nThis is a body section with more than fifty characters of prose content here.\n\n== References ==\n\n<references />\n\n== Bibliography ==\n\n* {{Cite vault | snapshot = x}}`;
+    const result = gradeCompleteness(page);
+    const cat = result.details.find((d) => d.check.includes('category'));
+    assert.ok(cat);
+    assert.equal(cat.passed, false);
+  });
+
+  it('scores very low for skeleton page with only boilerplate', () => {
+    // Only passes: lead (1), refs (0.5), bib (0.5), category (0.5), episode links vacuous (0.5) = 3.0/19
+    const page = `Lead paragraph.\n\n== Section ==\n\nShort content.\n\n== References ==\n\n<references />\n\n== Bibliography ==\n\n{{Cite vault | snapshot = x | type = y}}\n\n[[Category:Test]]`;
+    const result = gradeCompleteness(page);
+    assert.ok(result.score < 0.2, `Score ${result.score} should be < 0.2 for skeleton page`);
+  });
+
+  it('scores near 0 for empty input', () => {
+    // Only episode link check passes vacuously (0.5/19)
+    const result = gradeCompleteness('');
+    assert.ok(result.score < 0.05, `Score ${result.score} should be < 0.05 for empty input`);
+  });
+});
+
+describe('completeness grader — person role with episode links', () => {
+  it('passes when expected episode link is present', () => {
+    const page = FULL_PAGE + '\nSee also: [[Trip to Pondicherry]]\n';
+    const result = gradeCompleteness(page, {
+      role: 'person',
+      expectedEpisodes: ['Trip to Pondicherry'],
+    });
+    const check = result.details.find((d) => d.check.includes('episode'));
+    assert.ok(check);
+    assert.equal(check.passed, true);
+  });
+
+  it('fails when expected episode link is missing', () => {
+    const result = gradeCompleteness(FULL_PAGE, {
+      role: 'person',
+      expectedEpisodes: ['Trip to Pondicherry'],
+    });
+    const check = result.details.find((d) => d.check.includes('episode'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('passes when no expected episodes (vacuous truth)', () => {
+    const result = gradeCompleteness(FULL_PAGE, { role: 'person' });
+    const check = result.details.find((d) => d.check.includes('episode'));
+    assert.ok(check);
+    assert.equal(check.passed, true);
+  });
+});
+
+describe('completeness grader — episode role', () => {
+  const EPISODE_PAGE = `{{Infobox Episode
+| name = Trip to Pondicherry
+| date = 2024-01-15
+}}
+
+This is the lead paragraph about the trip to Pondicherry, a memorable three-day journey undertaken by the wiki owner and a close friend in January 2024, covering multiple locations along the southeastern coast of India and producing lasting memories documented across photos, voice notes, and diary entries.
+
+[[File:Pondicherry_beach.jpg|thumb|right|250px|Promenade Beach during sunset, 15 January 2024.]]
+
+== The journey ==
+
+The trip to Pondicherry began early in the morning. They drove along the coast for several hours taking in the beautiful scenery along the way. The route took them through several small towns and villages, each with its own character and charm. They stopped multiple times for photographs and to sample local street food from roadside vendors. The drive itself took about four hours with multiple stops along the East Coast Road.
+
+=== Day one ===
+
+The first day was spent exploring the French Quarter, visiting the Promenade Beach, and sampling the unique Franco-Tamil cuisine that Pondicherry is famous for. They visited the Sri Aurobindo Ashram and spent time at the Auroville township learning about its experimental community structure. The ashram grounds were peaceful and meditative. They walked through the garden and sat in the main meditation hall. At Auroville they visited the Matrimandir from a distance and explored the various community-run shops and cafes.
+
+{{Blockquote|The Matrimandir looked like something from another world, this massive golden sphere surrounded by gardens. Even from the viewing point you could feel the energy of the place.|Wiki owner, 15 January 2024}}<ref name="vn-01">{{Cite message|snapshot=trip456|date=2024-01-15|thread=pondicherry|note=Matrimandir voice note}}</ref>
+
+=== Day two ===
+
+The second day focused on the beach and the old colonial architecture. They rented bicycles and rode along the promenade in the early morning before the heat became unbearable. The French colonial buildings were painted in yellows and whites giving the neighbourhood a distinctly European feel. They visited the Pondicherry Museum and the old lighthouse before lunch at a small family-run restaurant.<ref name="vn-02">{{Cite message|snapshot=trip456|date=2024-01-16|thread=pondicherry|note=Day two cycling}}</ref>
+
+=== Day three ===
+
+The final day was a quiet one. They visited the botanical garden in the morning, packed their bags, and made one last stop at the fish market before driving home. The return journey was reflective and quiet with both travelers lost in thought about the experiences of the past three days.<ref name="vn-03">{{Cite message|snapshot=trip456|date=2024-01-17|thread=pondicherry|note=Day three departure}}</ref>
+
+== The food ==
+
+Pondicherry offered an incredible variety of food experiences. From traditional Tamil thalis to French-inspired bakeries, the culinary diversity was remarkable. They tried fresh seafood at a beachside restaurant and visited a local market where they purchased spices and handmade chocolates. The crepes at Cafe des Arts were particularly memorable. They also discovered a small Tamil restaurant near the bus stand that served the best fish curry either of them had ever tasted. Each meal became its own small adventure in the trip's narrative.<ref name="food-01">{{Cite message|snapshot=trip456|date=2024-01-15|thread=pondicherry|note=Food experiences}}</ref>
+
+== The people ==
+
+Along the way they met several interesting characters: a French expat who had lived in Pondicherry for thirty years and ran a small bookshop specialising in Tamil literature translated into French, a fisherman who told them stories about cyclone Thane and how the community rebuilt afterward, and the owner of their guesthouse who shared recipes for authentic Pondicherry rasam and taught them the difference between Pondicherry and Chennai cooking styles. These encounters enriched the trip beyond the standard tourist experience and gave them insights into the daily life of the town. The bookshop owner in particular made an impression, sharing stories about the early days of the Pondicherry literary scene and recommending several authors they had never heard of. The fisherman invited them to his home where his wife served fresh karimeen fry and they sat on the beach watching the sunset while he described how the fishing industry had changed over his lifetime. These personal connections transformed what could have been a routine tourist trip into something genuinely meaningful.<ref name="people-01">{{Cite message|snapshot=trip456|date=2024-01-16|thread=pondicherry|note=People met}}</ref>
+
+== Reflections ==
+
+The trip left a lasting impression on both travelers. They discussed how the blend of French and Tamil cultures created something entirely unique, and how the peaceful atmosphere of the town provided a welcome contrast to their busy city lives. The quiet mornings on the beach and the long conversations over coffee became defining memories of the friendship. In retrospect this trip marked a turning point in their relationship as they moved from casual acquaintances to genuine close friends. They spent the drive home discussing what made the trip special: the absence of any fixed agenda, the willingness to change plans on a whim, and the discovery that they could spend three days together without running out of conversation. The experience reinforced their shared preference for spontaneous travel over meticulously planned itineraries. They agreed that the best moments were unplanned: stumbling upon the tiny Tamil restaurant near the bus stand, deciding to rent bicycles at six in the morning, and the impromptu conversation with the French bookshop owner that lasted two hours.<ref name="reflect-01">{{Cite message|snapshot=trip456|date=2024-01-17|thread=pondicherry|note=Reflections}}</ref>
+
+== Impact ==
+
+This trip became a reference point in subsequent conversations. They would regularly say things like "remember that fish curry in Pondicherry" or "the Matrimandir energy" as shorthand for shared experiences. The photos from the trip were among the most frequently shared in their message thread in the months that followed. The bicycle ride along the promenade became a recurring suggestion whenever either of them needed to clear their head. The trip also introduced them to several new restaurants and food traditions that they continued to seek out in their home city. In many ways the Pondicherry trip marked the transition from acquaintances who happened to share mutual friends to genuine close friends who actively sought out each other's company. The shared vocabulary of inside jokes and references that emerged from those three days persisted for months and coloured nearly every subsequent interaction between them.<ref name="impact-01">{{Cite message|snapshot=trip456|date=2024-02-15|thread=pondicherry|note=Impact}}</ref><ref name="impact-02">{{Cite message|snapshot=trip456|date=2024-03-01|thread=pondicherry|note=Later references}}</ref><ref name="impact-03">{{Cite message|snapshot=trip456|date=2024-04-10|thread=pondicherry|note=Photo sharing}}</ref><ref name="impact-04">{{Cite message|snapshot=trip456|date=2024-05-20|thread=pondicherry|note=One of many callbacks}}</ref>
+
+See also: [[Jane Doe]]
+
+== References ==
+
+<references />
+
+== Bibliography ==
+
+* {{Cite vault | snapshot = trip456 | type = photos | description = Trip photos}}
+
+[[Category:Episodes]]
+`;
+
+  it('scores 1.0 for a complete episode with person link', () => {
+    const result = gradeCompleteness(EPISODE_PAGE, {
+      role: 'episode',
+      subject: 'Jane Doe',
+    });
+    assert.equal(result.score, 1, `Failed checks: ${result.details.filter((d) => !d.passed).map((d) => d.check).join(', ')}`);
+    assert.ok(result.details.every((d) => d.passed));
+  });
+
+  it('fails when person link is missing', () => {
+    const pageWithoutLink = EPISODE_PAGE.replace('See also: [[Jane Doe]]', '');
+    const result = gradeCompleteness(pageWithoutLink, {
+      role: 'episode',
+      subject: 'Jane Doe',
+    });
+    const check = result.details.find((d) => d.check.includes('person page'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('passes when no subject provided (vacuous truth)', () => {
+    const result = gradeCompleteness(EPISODE_PAGE, { role: 'episode' });
+    const check = result.details.find((d) => d.check.includes('person page'));
+    assert.ok(check);
+    assert.equal(check.passed, true);
+  });
+});
+
+describe('completeness grader — talk role', () => {
+  const TALK_PAGE = `== Editorial decisions ==
+
+{{Closed}} Decided to focus on the Bangalore period.
+
+== Active gaps ==
+
+{{Open}} Missing birth date.
+
+== Research notes ==
+
+Key findings from source review.
+`;
+
+  it('scores 1.0 for a complete talk page', () => {
+    const result = gradeCompleteness(TALK_PAGE, { role: 'talk' });
+    assert.equal(result.score, 1, `Failed checks: ${result.details.filter((d) => !d.passed).map((d) => d.check).join(', ')}`);
+    assert.equal(result.details.length, 5);
+    assert.ok(result.details.every((d) => d.passed));
+  });
+
+  it('has 5 checks for talk role', () => {
+    const result = gradeCompleteness('', { role: 'talk' });
+    assert.equal(result.details.length, 5);
+  });
+
+  it('detects missing section heading', () => {
+    const page = 'Just some text with no headings.';
+    const result = gradeCompleteness(page, { role: 'talk' });
+    const check = result.details.find((d) => d.check.includes('section heading'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('detects missing editorial decisions', () => {
+    const page = `== Notes ==\n\nSome notes.\n\n== Active gaps ==\n\n{{Open}} Missing info.`;
+    const result = gradeCompleteness(page, { role: 'talk' });
+    const check = result.details.find((d) => d.check.includes('editorial decisions'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('detects lead prose before first heading', () => {
+    const page = `This is lead prose.\n\n== Editorial decisions ==\n\n{{Closed}} Done.\n\n== Active gaps ==\n\n{{Open}} Gap.`;
+    const result = gradeCompleteness(page, { role: 'talk' });
+    const check = result.details.find((d) => d.check.includes('lead prose'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('passes editorial decisions check via {{Closed}} template', () => {
+    const page = `== Work ==\n\n{{Closed}} Resolved.\n\n== Active gaps ==\n\n{{Open}} Gap.`;
+    const result = gradeCompleteness(page, { role: 'talk' });
+    const check = result.details.find((d) => d.check.includes('editorial decisions'));
+    assert.ok(check);
+    assert.equal(check.passed, true);
+  });
+});
+
+describe('completeness grader — source role', () => {
+  const SOURCE_PAGE = `{{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive export}}
+
+== Contents ==
+
+This source page documents the Facebook data archive. It contains posts, messages, photos, and profile metadata exported from the platform. The archive was created on 2024-01-15 and spans approximately six years of activity. The export includes structured JSON files for each data category, along with media attachments stored in their original format. The total size of the archive is approximately 2.3 GB.
+
+=== Posts ===
+
+Timeline posts and status updates spanning from 2018 to 2024. Includes 1,247 text posts, 892 photo posts, and 156 video posts. Posts are organized chronologically in JSON format with associated metadata including timestamps, privacy settings, and engagement metrics.
+
+=== Messages ===
+
+Direct message conversations with 42 contacts. The messages archive contains approximately 15,000 individual messages across all threads. Each conversation is stored as a separate JSON file containing sender information, timestamps, message content, and any attached media references.
+
+== Querying ==
+
+The archive can be queried using standard JSON parsing tools. Each data category is stored in a separate directory with consistent file naming conventions. The posts directory contains yearly JSON files, while the messages directory contains per-conversation JSON files.
+
+[[Category:Sources]]
+`;
+
+  it('scores 1.0 for a complete source page', () => {
+    const result = gradeCompleteness(SOURCE_PAGE, { role: 'source' });
+    assert.equal(result.grader, 'completeness');
+    assert.equal(result.score, 1);
+    assert.equal(result.details.length, 6);
+    assert.ok(result.details.every((d) => d.passed));
+  });
+
+  it('has 6 checks for source role', () => {
+    const result = gradeCompleteness('', { role: 'source' });
+    assert.equal(result.details.length, 6);
+  });
+
+  it('detects missing snapshot identifier', () => {
+    const page = `== Contents ==\n\nSome content here that is longer than one hundred characters to pass the content summary check. It goes on for a while to make sure it is long enough.\n\n[[Category:Sources]]`;
+    const result = gradeCompleteness(page, { role: 'source' });
+    const check = result.details.find((d) => d.check.includes('snapshot'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('detects missing source type metadata', () => {
+    const page = `{{Cite vault | snapshot = abc123}}\n\n== Contents ==\n\nSome content here that is longer than one hundred characters to pass the content summary check. It goes on for a while to make sure it is long enough.\n\n[[Category:Sources]]`;
+    const result = gradeCompleteness(page, { role: 'source' });
+    const check = result.details.find((d) => d.check.includes('source type'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('detects missing content summary', () => {
+    const page = `{{Cite vault | snapshot = abc123 | type = photos}}\n\nShort.\n\n[[Category:Sources]]`;
+    const result = gradeCompleteness(page, { role: 'source' });
+    const check = result.details.find((d) => d.check.includes('file listing'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+
+  it('detects missing category tag', () => {
+    const page = `{{Cite vault | snapshot = abc123 | type = photos}}\n\n== Contents ==\n\nThis source page documents the photo archive. It contains many photos spanning multiple years with detailed metadata and location information attached to each one.`;
+    const result = gradeCompleteness(page, { role: 'source' });
+    const check = result.details.find((d) => d.check.includes('category'));
+    assert.ok(check);
+    assert.equal(check.passed, false);
+  });
+});

--- a/evals/test/reference.test.ts
+++ b/evals/test/reference.test.ts
@@ -1,0 +1,290 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { gradeReference } from '../src/graders/reference.js';
+
+const REFERENCE_PERSON = `{{Infobox Person
+| name = Test Subject
+| birth_date = 1990-01-01
+| location = Mumbai
+| sources = Facebook, WhatsApp
+}}
+
+Test Subject is a person documented through social media archives.
+
+== Early life ==
+
+Test Subject grew up in Mumbai.
+
+== Career ==
+
+Test Subject worked in technology.
+
+== Personal life ==
+
+Test Subject enjoys travel and photography.
+
+== References ==
+
+<references />
+
+== Bibliography ==
+
+* {{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive}}
+* {{Cite vault | snapshot = whatsapp-export | type = whatsapp | description = WhatsApp archive}}
+
+[[Category:People]]
+[[Category:Mumbai residents]]
+`;
+
+describe('reference grader — content pages', () => {
+  it('scores 1.0 when agent output matches reference exactly', () => {
+    const result = gradeReference(REFERENCE_PERSON, REFERENCE_PERSON, 'person');
+    assert.equal(result.grader, 'reference');
+    assert.equal(result.score, 1);
+    assert.equal(result.details.length, 4);
+  });
+
+  it('scores section heading coverage', () => {
+    // Agent has 2 of 4 body headings (Early life, References, Bibliography missing Career and Personal life)
+    const agent = `{{Infobox Person
+| name = Test Subject
+| birth_date = 1990-01-01
+| location = Mumbai
+| sources = Facebook, WhatsApp
+}}
+
+Test Subject is a person.
+
+== Early life ==
+
+Grew up in Mumbai.
+
+== References ==
+
+<references />
+
+== Bibliography ==
+
+* {{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive}}
+* {{Cite vault | snapshot = whatsapp-export | type = whatsapp | description = WhatsApp archive}}
+
+[[Category:People]]
+[[Category:Mumbai residents]]
+`;
+    const result = gradeReference(agent, REFERENCE_PERSON, 'person');
+    const headings = result.details.find((d) => d.check.includes('Section heading'));
+    assert.ok(headings);
+    // 3 of 5 headings present (Early life, References, Bibliography) — missing Career and Personal life
+    assert.ok(headings.note?.includes('/5'));
+  });
+
+  it('scores infobox field coverage', () => {
+    // Agent has only 2 of 4 infobox fields
+    const agent = `{{Infobox Person
+| name = Test Subject
+| location = Mumbai
+}}
+
+Test Subject is a person.
+
+== Early life ==
+
+Grew up in Mumbai.
+
+== Career ==
+
+Works in tech.
+
+== Personal life ==
+
+Enjoys travel.
+
+== References ==
+
+<references />
+
+== Bibliography ==
+
+* {{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive}}
+* {{Cite vault | snapshot = whatsapp-export | type = whatsapp | description = WhatsApp archive}}
+
+[[Category:People]]
+[[Category:Mumbai residents]]
+`;
+    const result = gradeReference(agent, REFERENCE_PERSON, 'person');
+    const fields = result.details.find((d) => d.check.includes('Infobox field'));
+    assert.ok(fields);
+    assert.ok(fields.note?.includes('2/4'));
+  });
+
+  it('scores citation hash coverage', () => {
+    // Agent has only 1 of 2 citation hashes
+    const agent = `{{Infobox Person
+| name = Test Subject
+| birth_date = 1990-01-01
+| location = Mumbai
+| sources = Facebook, WhatsApp
+}}
+
+Test Subject is a person.
+
+== Early life ==
+
+Grew up in Mumbai.
+
+== Career ==
+
+Works in tech.
+
+== Personal life ==
+
+Enjoys travel.
+
+== References ==
+
+<references />
+
+== Bibliography ==
+
+* {{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive}}
+
+[[Category:People]]
+[[Category:Mumbai residents]]
+`;
+    const result = gradeReference(agent, REFERENCE_PERSON, 'person');
+    const hashes = result.details.find((d) => d.check.includes('Citation hash'));
+    assert.ok(hashes);
+    assert.ok(hashes.note?.includes('1/2'));
+  });
+
+  it('scores category coverage', () => {
+    // Agent has only 1 of 2 categories
+    const agent = `{{Infobox Person
+| name = Test Subject
+| birth_date = 1990-01-01
+| location = Mumbai
+| sources = Facebook, WhatsApp
+}}
+
+Test Subject is a person.
+
+== Early life ==
+
+Grew up in Mumbai.
+
+== Career ==
+
+Works in tech.
+
+== Personal life ==
+
+Enjoys travel.
+
+== References ==
+
+<references />
+
+== Bibliography ==
+
+* {{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive}}
+* {{Cite vault | snapshot = whatsapp-export | type = whatsapp | description = WhatsApp archive}}
+
+[[Category:People]]
+`;
+    const result = gradeReference(agent, REFERENCE_PERSON, 'person');
+    const cats = result.details.find((d) => d.check.includes('Category'));
+    assert.ok(cats);
+    assert.ok(cats.note?.includes('1/2'));
+  });
+
+  it('scores 0 for completely empty agent output', () => {
+    const result = gradeReference('', REFERENCE_PERSON, 'person');
+    assert.ok(result.score < 0.1);
+  });
+
+  it('works for talk pages', () => {
+    const reference = `== Agent log ==\n\n=== Task: Write page ===\n\nDone.\n\n== Active gaps ==\n\n{{Open}} Missing data.`;
+    const agent = `== Agent log ==\n\n=== Task: Write page ===\n\nCompleted.\n\n== Active gaps ==\n\n{{Open}} Gaps remain.`;
+    const result = gradeReference(agent, reference, 'talk');
+    assert.equal(result.grader, 'reference');
+    // Both headings match
+    const headings = result.details.find((d) => d.check.includes('Section heading'));
+    assert.ok(headings);
+    assert.ok(headings.passed);
+  });
+});
+
+describe('reference grader — source pages', () => {
+  const REFERENCE_SOURCE = `{{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive export}}
+
+== Contents ==
+
+This source page documents the Facebook data archive for Test Subject. It contains posts, messages, photos, and profile metadata exported from the platform.
+
+=== Posts ===
+
+Timeline posts and status updates.
+
+=== Messages ===
+
+Direct message conversations.
+
+=== Photos ===
+
+Uploaded photos and albums.
+
+[[Category:Sources]]
+`;
+
+  it('scores 1.0 when agent matches reference exactly', () => {
+    const result = gradeReference(REFERENCE_SOURCE, REFERENCE_SOURCE, 'source');
+    assert.equal(result.grader, 'reference');
+    assert.equal(result.score, 1);
+    assert.equal(result.details.length, 2);
+  });
+
+  it('scores content length ratio', () => {
+    // Agent output is shorter than reference
+    const agent = `{{Cite vault | snapshot = facebook-export | type = facebook}}\n\nShort page.`;
+    const result = gradeReference(agent, REFERENCE_SOURCE, 'source');
+    const ratio = result.details.find((d) => d.check.includes('Content length'));
+    assert.ok(ratio);
+    assert.ok(ratio.penalty > 0);
+  });
+
+  it('caps content length ratio at 1.0 for longer output', () => {
+    // Agent output is longer than reference
+    const agent = REFERENCE_SOURCE + '\n\nExtra content here that makes this much longer than the reference. '.repeat(10);
+    const result = gradeReference(agent, REFERENCE_SOURCE, 'source');
+    const ratio = result.details.find((d) => d.check.includes('Content length'));
+    assert.ok(ratio);
+    assert.ok(ratio.note?.includes('100%'));
+  });
+
+  it('scores key line coverage', () => {
+    // Agent has some but not all reference lines
+    const agent = `{{Cite vault | snapshot = facebook-export | type = facebook | description = Facebook archive export}}
+
+== Contents ==
+
+This source page documents the Facebook data archive for Test Subject. It contains posts, messages, photos, and profile metadata exported from the platform.
+
+=== Posts ===
+
+Timeline posts and status updates.
+
+[[Category:Sources]]
+`;
+    const result = gradeReference(agent, REFERENCE_SOURCE, 'source');
+    const lines = result.details.find((d) => d.check.includes('Key line'));
+    assert.ok(lines);
+    // Not all lines are present but some are
+    assert.ok(lines.penalty > 0);
+    assert.ok(result.score > 0.3);
+  });
+
+  it('scores 0 for empty agent output against non-empty reference', () => {
+    const result = gradeReference('', REFERENCE_SOURCE, 'source');
+    assert.equal(result.score, 0);
+  });
+});

--- a/evals/test/vault.test.ts
+++ b/evals/test/vault.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import {
+  readManifest,
+  readObject,
+  findInManifest,
+  findAllInManifest,
+  extractMessagesNearDate,
+} from '../src/vault.js';
+import { resolveCitations } from '../src/graders/citation-resolver.js';
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `vault-test-${randomBytes(4).toString('hex')}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('readManifest', () => {
+  let vaultPath: string;
+
+  beforeEach(() => {
+    vaultPath = createTempDir();
+    mkdirSync(join(vaultPath, 'snapshots'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(vaultPath, { recursive: true, force: true });
+  });
+
+  it('reads a valid manifest', () => {
+    const manifest = {
+      files: [
+        { path: 'messages/thread_123/message_1.json', hash: 'abc123def456' },
+        { path: 'photos/photo_1.jpg', hash: 'fff000111222' },
+      ],
+    };
+    writeFileSync(
+      join(vaultPath, 'snapshots', 'snap1234.json'),
+      JSON.stringify(manifest),
+    );
+
+    const result = readManifest(vaultPath, 'snap1234');
+    assert.notEqual(result, null);
+    assert.equal(result!.files.length, 2);
+    assert.equal(result!.files[0].path, 'messages/thread_123/message_1.json');
+  });
+
+  it('returns null for missing manifest', () => {
+    const result = readManifest(vaultPath, 'nonexistent');
+    assert.equal(result, null);
+  });
+
+  it('returns null for invalid JSON', () => {
+    writeFileSync(join(vaultPath, 'snapshots', 'bad.json'), 'not json');
+    const result = readManifest(vaultPath, 'bad');
+    assert.equal(result, null);
+  });
+});
+
+describe('readObject', () => {
+  let vaultPath: string;
+
+  beforeEach(() => {
+    vaultPath = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(vaultPath, { recursive: true, force: true });
+  });
+
+  it('reads an object by hash', () => {
+    const hash = 'abcdef1234567890';
+    const prefix = hash.slice(0, 2);
+    mkdirSync(join(vaultPath, 'objects', prefix), { recursive: true });
+    writeFileSync(join(vaultPath, 'objects', prefix, hash), 'file contents');
+
+    const result = readObject(vaultPath, hash);
+    assert.notEqual(result, null);
+    assert.equal(result!.toString('utf-8'), 'file contents');
+  });
+
+  it('returns null for missing object', () => {
+    const result = readObject(vaultPath, 'deadbeef00000000');
+    assert.equal(result, null);
+  });
+});
+
+describe('findInManifest', () => {
+  const manifest = {
+    files: [
+      { path: 'messages/test_contact_100200300/message_1.json', hash: 'aaa' },
+      { path: 'messages/test_contact_100200300/message_2.json', hash: 'bbb' },
+      { path: 'photos/photo_1.jpg', hash: 'ccc' },
+    ],
+  };
+
+  it('finds a file matching thread directory', () => {
+    const result = findInManifest(manifest, (p) =>
+      p.includes('test_contact_100200300') && p.endsWith('.json'),
+    );
+    assert.notEqual(result, undefined);
+    assert.equal(result!.hash, 'aaa');
+  });
+
+  it('returns undefined when no match', () => {
+    const result = findInManifest(manifest, (p) => p.includes('nonexistent'));
+    assert.equal(result, undefined);
+  });
+});
+
+describe('findAllInManifest', () => {
+  const manifest = {
+    files: [
+      { path: 'messages/test_contact_100200300/message_1.json', hash: 'aaa' },
+      { path: 'messages/test_contact_100200300/message_2.json', hash: 'bbb' },
+      { path: 'photos/photo_1.jpg', hash: 'ccc' },
+    ],
+  };
+
+  it('finds all files matching predicate', () => {
+    const results = findAllInManifest(manifest, (p) =>
+      p.includes('test_contact_100200300'),
+    );
+    assert.equal(results.length, 2);
+  });
+
+  it('returns empty array when no match', () => {
+    const results = findAllInManifest(manifest, (p) => p.includes('nonexistent'));
+    assert.equal(results.length, 0);
+  });
+});
+
+describe('extractMessagesNearDate', () => {
+  const threadJson = JSON.stringify({
+    participants: [{ name: 'Owner' }, { name: 'Contact' }],
+    messages: [
+      { sender_name: 'Owner', timestamp_ms: 1573689600000, content: 'Hello' },       // 2019-11-14
+      { sender_name: 'Contact', timestamp_ms: 1573700400000, content: 'Hi there!' },    // 2019-11-14
+      { sender_name: 'Owner', timestamp_ms: 1573776000000, content: 'Day 2 msg' },   // 2019-11-15
+      { sender_name: 'Contact', timestamp_ms: 1574294400000, content: 'Much later' },   // 2019-11-21
+    ],
+  });
+
+  it('extracts messages within window', () => {
+    const result = extractMessagesNearDate(threadJson, '2019-11-14', 1);
+    assert.ok(result.includes('Owner: Hello'));
+    assert.ok(result.includes('Contact: Hi there!'));
+    assert.ok(result.includes('Owner: Day 2 msg'));
+    assert.ok(!result.includes('Much later'));
+  });
+
+  it('returns empty string for date with no messages', () => {
+    const result = extractMessagesNearDate(threadJson, '2020-06-01', 1);
+    assert.equal(result, '');
+  });
+
+  it('includes participant info', () => {
+    const result = extractMessagesNearDate(threadJson, '2019-11-14', 1);
+    assert.ok(result.includes('Owner'));
+    assert.ok(result.includes('Contact'));
+  });
+
+  it('returns empty string for invalid JSON', () => {
+    const result = extractMessagesNearDate('not json', '2019-11-14');
+    assert.equal(result, '');
+  });
+
+  it('returns empty string for missing messages array', () => {
+    const result = extractMessagesNearDate('{"participants": []}', '2019-11-14');
+    assert.equal(result, '');
+  });
+
+  it('caps at 50 messages', () => {
+    const messages = Array.from({ length: 100 }, (_, i) => ({
+      sender_name: 'Test',
+      timestamp_ms: 1573689600000 + i * 1000,
+      content: `msg ${i}`,
+    }));
+    const json = JSON.stringify({ participants: [{ name: 'Test' }], messages });
+    const result = extractMessagesNearDate(json, '2019-11-14', 1);
+    const lines = result.split('\n').filter((l) => l.startsWith('['));
+    assert.equal(lines.length, 50);
+  });
+});
+
+describe('resolveCitations', () => {
+  let vaultPath: string;
+
+  beforeEach(() => {
+    vaultPath = createTempDir();
+    mkdirSync(join(vaultPath, 'snapshots'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(vaultPath, { recursive: true, force: true });
+  });
+
+  it('resolves a message citation from vault', () => {
+    // Set up manifest
+    const hash = 'ab1234567890abcdef';
+    const manifest = {
+      files: [
+        { path: 'messages/test_contact_100200300/message_1.json', hash },
+      ],
+    };
+    writeFileSync(
+      join(vaultPath, 'snapshots', '329f2f56f6122638.json'),
+      JSON.stringify(manifest),
+    );
+
+    // Set up object
+    const prefix = hash.slice(0, 2);
+    mkdirSync(join(vaultPath, 'objects', prefix), { recursive: true });
+    const msgData = {
+      participants: [{ name: 'Owner' }, { name: 'Contact' }],
+      messages: [
+        { sender_name: 'Contact', timestamp_ms: 1573689600000, content: 'Hello from November 14' },
+      ],
+    };
+    writeFileSync(
+      join(vaultPath, 'objects', prefix, hash),
+      JSON.stringify(msgData),
+    );
+
+    const wikitext = '{{Cite message | snapshot=329f2f56f6122638 | date=2019-11-14 | thread=test_contact_100200300 | author=Contact}}';
+    const results = resolveCitations(wikitext, vaultPath);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].resolved, true);
+    assert.ok(results[0].sourceExcerpt.includes('Hello from November 14'));
+  });
+
+  it('returns unresolved for missing manifest', () => {
+    const wikitext = '{{Cite message | snapshot=nonexistent | date=2019-11-14 | thread=test | author=Test}}';
+    const results = resolveCitations(wikitext, vaultPath);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].resolved, false);
+    assert.ok(results[0].error?.includes('Manifest not found'));
+  });
+
+  it('resolves a direct hash citation', () => {
+    const hash = 'cd9876543210fedcba';
+    const prefix = hash.slice(0, 2);
+    mkdirSync(join(vaultPath, 'objects', prefix), { recursive: true });
+    writeFileSync(join(vaultPath, 'objects', prefix, hash), 'raw object data');
+
+    const wikitext = `{{Cite photo | hash=${hash} | date=2020-01-01}}`;
+    const results = resolveCitations(wikitext, vaultPath);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].resolved, true);
+    assert.ok(results[0].sourceExcerpt.includes('raw object data'));
+  });
+
+  it('handles wikitext with no citations', () => {
+    const results = resolveCitations('Just some text.', vaultPath);
+    assert.equal(results.length, 0);
+  });
+
+  it('handles multiple citations with cache reuse', () => {
+    const hash = 'ef1234567890abcdef';
+    const manifest = {
+      files: [
+        { path: 'messages/thread_1/message_1.json', hash },
+      ],
+    };
+    writeFileSync(
+      join(vaultPath, 'snapshots', 'snap123.json'),
+      JSON.stringify(manifest),
+    );
+
+    const prefix = hash.slice(0, 2);
+    mkdirSync(join(vaultPath, 'objects', prefix), { recursive: true });
+    const msgData = {
+      participants: [{ name: 'Alice' }],
+      messages: [
+        { sender_name: 'Alice', timestamp_ms: 1573689600000, content: 'msg1' },
+        { sender_name: 'Alice', timestamp_ms: 1573776000000, content: 'msg2' },
+      ],
+    };
+    writeFileSync(join(vaultPath, 'objects', prefix, hash), JSON.stringify(msgData));
+
+    const wikitext = [
+      '{{Cite message | snapshot=snap123 | date=2019-11-14 | thread=thread_1 | author=Alice}}',
+      '{{Cite message | snapshot=snap123 | date=2019-11-15 | thread=thread_1 | author=Alice}}',
+    ].join('\n');
+
+    const results = resolveCitations(wikitext, vaultPath);
+    assert.equal(results.length, 2);
+    assert.equal(results[0].resolved, true);
+    assert.equal(results[1].resolved, true);
+  });
+});

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary

- Add evaluation toolkit for measuring editorial agent quality across three page types (person, episode, project)
- Six graders (completeness, citations, editorial, reference, accuracy, cross-ref) score agent output on a 0–1 scale
- Incremental checkpoint runner progressively introduces sources and gates on quality thresholds
- Three harness adapters: Claude Code, Codex, OpenCode
- Example fixtures with synthetic data for all three page types (real fixtures gitignored)
- `/create-fixture` skill for interactively generating new fixtures
- Isolated MediaWiki instances per run via the desktop app's bundled resources

## Test plan

- [x] All 76 unit tests pass (`pnpm test`)
- [x] No personal data in committed files (PII scan verified)
- [x] Real fixtures gitignored, example fixtures committed with synthetic data
- [x] End-to-end run with `--suite incremental --harness claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)