### PR TITLE
feat: server render docs sidebar to avoid layout shift

### DIFF
--- a/web/app/docs/[slug]/page.tsx
+++ b/web/app/docs/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getDoc, getAllDocs } from "@/lib/docs";
+import { getSidebarConfig } from "@/lib/docs-sidebar-config";
+import { DocsSidebarServer } from "@/components/docs-sidebar-server";
 import { MDXContent } from "@/components/mdx-content";
 import { MarkdownBlocks } from "@/components/markdown-blocks";
 import { CopyCodeBlock } from "@/components/copy-code-block";
@@ -82,13 +84,22 @@ export default async function DocPage({ params }: Props) {
   const doc = getDoc(slug);
   if (!doc) notFound();
 
+  const sections = getSidebarConfig();
+
   return (
-    <div className="flex flex-col gap-6">
-      <h1 className="font-sans text-2xl font-medium">{doc.title}</h1>
-      <div className="h-px w-full bg-neutral-200 dark:bg-neutral-700" />
-      <article className="font-sans text-neutral-700 dark:text-neutral-300 prose dark:prose-invert prose-strong:font-normal prose-p:leading-6.5 prose-img:rounded-xl prose-li:m-0 prose-p:m-0 prose-ul:mt-0 prose-code:before:content-none prose-code:after:content-none flex flex-col gap-4 prose-headings:mb-0 prose-ol:mt-0 prose-pre:m-0 prose-th:font-normal prose-blockquote:not-italic prose-blockquote:font-normal prose-blockquote:before:content-none">
-        <MDXContent source={doc.content} components={docsComponents} />
-      </article>
-    </div>
+    <>
+      <div className="hidden md:block self-start sticky top-18">
+        <DocsSidebarServer sections={sections} activeSlug={slug} />
+      </div>
+      <main className="min-w-0 flex-1">
+        <div className="flex flex-col gap-6">
+          <h1 className="font-sans text-2xl font-medium">{doc.title}</h1>
+          <div className="h-px w-full bg-neutral-200 dark:bg-neutral-700" />
+          <article className="font-sans text-neutral-700 dark:text-neutral-300 prose dark:prose-invert prose-strong:font-normal prose-p:leading-6.5 prose-img:rounded-xl prose-li:m-0 prose-p:m-0 prose-ul:mt-0 prose-code:before:content-none prose-code:after:content-none flex flex-col gap-4 prose-headings:mb-0 prose-ol:mt-0 prose-pre:m-0 prose-th:font-normal prose-blockquote:not-italic prose-blockquote:font-normal prose-blockquote:before:content-none">
+            <MDXContent source={doc.content} components={docsComponents} />
+          </article>
+        </div>
+      </main>
+    </>
   );
 }

--- a/web/app/docs/layout.tsx
+++ b/web/app/docs/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { DocsSidebar } from "@/components/docs-sidebar";
 import { DocsMobileNav } from "@/components/docs-mobile-nav";
 import { getSidebarConfig } from "@/lib/docs-sidebar-config";
 
@@ -19,10 +18,7 @@ export default function DocsLayout({
     <div className="flex flex-col w-dvw items-center">
       <DocsMobileNav sections={sections} />
       <div className="w-full max-w-5xl flex flex-row gap-8 py-18 px-6">
-        <div className="hidden md:block self-start sticky top-18">
-          <DocsSidebar sections={sections} />
-        </div>
-        <main className="min-w-0 flex-1">{children}</main>
+        {children}
       </div>
     </div>
   );

--- a/web/components/docs-sidebar-server.tsx
+++ b/web/components/docs-sidebar-server.tsx
@@ -1,0 +1,52 @@
+import cn from "classnames";
+import Link from "next/link";
+import type { SidebarSection } from "@/lib/docs-sidebar-config";
+import { SidebarHeadingTracker } from "./sidebar-heading-tracker";
+
+export function DocsSidebarServer({
+  sections,
+  activeSlug,
+}: {
+  sections: SidebarSection[];
+  activeSlug: string;
+}) {
+  return (
+    <nav className="w-56 shrink-0 font-sans text-sm max-h-[calc(100dvh-5rem)] overflow-y-auto">
+      <div className="flex flex-col gap-6">
+        {sections.map((section) => (
+          <div key={section.title} className="flex flex-col gap-1">
+            <div className="text-primary text-sm mb-1">{section.title}</div>
+
+            {section.items.map((item) => {
+              const href = `/docs/${item.slug}`;
+              const isActive = item.slug === activeSlug;
+
+              return (
+                <div key={item.slug} className="flex flex-col gap-2">
+                  <Link
+                    href={href}
+                    className={cn(
+                      "py-1 text-sm pl-3",
+                      isActive
+                        ? "text-neutral-900 dark:text-neutral-100"
+                        : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300",
+                    )}
+                  >
+                    {item.title}
+                  </Link>
+
+                  {isActive && item.headings.length > 0 && (
+                    <SidebarHeadingTracker
+                      headings={item.headings}
+                      href={href}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/web/components/sidebar-heading-tracker.tsx
+++ b/web/components/sidebar-heading-tracker.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import cn from "classnames";
+import type { DocHeading } from "@/lib/docs";
+
+export function SidebarHeadingTracker({
+  headings,
+  href,
+}: {
+  headings: DocHeading[];
+  href: string;
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -70% 0px", threshold: 0 },
+    );
+
+    for (const heading of headings) {
+      const el = document.getElementById(heading.id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return (
+    <div className="flex flex-col gap-1 ml-3 border-l border-neutral-200 dark:border-neutral-700 pl-3 mb-2">
+      {headings.map((heading) => (
+        <Link
+          key={heading.id}
+          href={`${href}#${heading.id}`}
+          onClick={(e) => {
+            const el = document.getElementById(heading.id);
+            if (el) {
+              e.preventDefault();
+              el.scrollIntoView({ behavior: "smooth" });
+              window.history.replaceState(null, "", `${href}#${heading.id}`);
+            }
+          }}
+          className={cn(
+            "py-0.5 text-sm transition-colors",
+            activeId === heading.id
+              ? "text-neutral-900 dark:text-neutral-100"
+              : "text-neutral-400 dark:text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300",
+          )}
+        >
+          {heading.title}
+        </Link>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Moved the desktop sidebar from `layout.tsx` into `[slug]/page.tsx` where the active slug is known at build time
- Created `DocsSidebarServer` (server component) that determines the active page from the slug prop instead of `usePathname()`
- Created `SidebarHeadingTracker` (client component) for only the scroll-based heading highlight via IntersectionObserver
- The nav links, active page state, and heading list are now in the static HTML with no client-side layout shift
- Mobile drawer nav is unchanged (still uses the existing client `DocsSidebar`)

## Test plan

- [x] Verify docs pages render correctly with sidebar on desktop
- [x] Verify active page and heading list appear immediately without layout shift
- [x] Verify heading scroll tracking still highlights the active section
- [x] Verify mobile drawer nav still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)