### PR TITLE
fix: handle cmd+r to reload wiki view in desktop app

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -297,6 +297,8 @@ async function launchWiki(): Promise<void> {
       wikiView.webContents.goBack();
     } else if (input.meta && input.key === "]") {
       wikiView.webContents.goForward();
+    } else if (input.meta && input.key === "r") {
+      wikiView.webContents.reload();
     }
   };
   mainWindow.webContents.on("before-input-event", handleKeyboardNav);


### PR DESCRIPTION
## Summary
- Cmd+R in the desktop app was refreshing the navbar instead of the wiki content, because the wiki renders in a separate `WebContentsView`
- Adds `Cmd+R` handling to the existing keyboard shortcut handler so it reloads the wiki view

## Test plan
- [ ] Open the desktop app and navigate to a wiki page
- [ ] Press Cmd+R and verify the wiki content reloads (not just the navbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)