### PR TITLE
fix: add blur and scale-down feedback to copy button on press

### DIFF
--- a/web/components/copy-code-block.tsx
+++ b/web/components/copy-code-block.tsx
@@ -25,7 +25,7 @@ export function CopyCodeBlock({ children }: { children?: ReactNode }) {
 
       <button
         onClick={handleCopy}
-        className="size-fit mt-4 rounded-md text-neutral-400 hover:text-neutral-100 cursor-pointer"
+        className="size-fit mt-4 rounded-md text-neutral-400 hover:text-neutral-100 cursor-pointer transition-all duration-150 active:scale-90 active:blur-[2px]"
         aria-label="Copy to clipboard"
       >
         {copied ? <CheckIcon /> : <CopyIcon />}


### PR DESCRIPTION
## Summary
- Add `active:scale-90` and `active:blur-[2px]` to the docs copy-to-clipboard button
- The blur masks the icon swap animation (copy → check) and the scale-down gives tactile press feedback

## Test plan
- [x] Click the copy button on any docs code block and verify the press feels snappier
- [x] Confirm the icon transition from copy to check looks smooth with the blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)