### PR TITLE
fix: obfuscate password input and skip server prompt in cli auth login

### DIFF
--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -39,20 +39,19 @@ async function login(args: string[], globals: GlobalFlags): Promise<void> {
 
   // Interactive mode if any value is missing
   if (!server || !username || !password) {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    try {
-      if (!server) {
-        const ans = await rl.question('Wiki server [http://localhost:8080]: ');
-        server = ans.trim() || 'http://localhost:8080';
-      }
-      if (!username) {
+    if (!server) {
+      server = 'http://localhost:8080';
+    }
+    if (!username) {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      try {
         username = await rl.question('Username: ');
+      } finally {
+        rl.close();
       }
-      if (!password) {
-        password = await readPassword('Password: ');
-      }
-    } finally {
-      rl.close();
+    }
+    if (!password) {
+      password = await readPassword('Password: ');
     }
   }
 


### PR DESCRIPTION
## Summary
- Close the readline interface before reading the password so it doesn't echo characters alongside the asterisk masking
- Default the server to `http://localhost:8080` without prompting — users can still override with `--server`

## Test plan
- [x] Run `npx tsx src/index.ts auth login` and verify password shows `*` instead of characters
- [x] Verify `--server` flag still works for advanced users

🤖 Generated with [Claude Code](https://claude.com/claude-code)