### PR TITLE
feat: restructure evals docs into results page and reference page

### DIFF
--- a/web/components/fixture-overview.tsx
+++ b/web/components/fixture-overview.tsx
@@ -393,9 +393,61 @@ function GitHubContent() {
 /*  Main component                                                     */
 /* ------------------------------------------------------------------ */
 
-const labels = ["Person", "Trip", "Project"];
+const scenes = {
+  person: (
+    <>
+      <AppWindow className="left-[4%] top-[16%] w-[36%] h-[52%] z-10">
+        <InstagramContent />
+      </AppWindow>
+      <AppWindow className="left-[24%] top-[12%] w-[42%] h-[56%] z-20">
+        <PhotosContent />
+      </AppWindow>
+      <AppWindow className="left-[52%] top-[10%] w-[26%] h-[62%] z-30">
+        <WhatsAppContent />
+      </AppWindow>
+      <AppWindow className="left-[68%] top-[16%] w-[24%] h-[56%] z-40">
+        <MessagesContent />
+      </AppWindow>
+      <div className="absolute left-[6%] top-[52%] w-[30%] z-50">
+        <ClaudeCodeMini />
+      </div>
+    </>
+  ),
+  trip: (
+    <>
+      <AppWindow className="left-[4%] top-[12%] w-[46%] h-[60%] z-10">
+        <PhotosContent />
+      </AppWindow>
+      <AppWindow className="left-[34%] top-[16%] w-[38%] h-[56%] z-20">
+        <MapsContent />
+      </AppWindow>
+      <AppWindow className="left-[62%] top-[10%] w-[30%] h-[58%] z-30">
+        <TransactionsContent />
+      </AppWindow>
+      <div className="absolute left-[6%] top-[52%] w-[30%] z-40">
+        <ClaudeCodeMini />
+      </div>
+    </>
+  ),
+  project: (
+    <>
+      <AppWindow className="left-[6%] top-[12%] w-[44%] h-[62%] z-10">
+        <SlackContent />
+      </AppWindow>
+      <AppWindow className="left-[42%] top-[10%] w-[42%] h-[58%] z-20">
+        <GitHubContent />
+      </AppWindow>
+      <div className="absolute left-[10%] top-[50%] w-[32%] z-30">
+        <ClaudeCodeMini />
+      </div>
+    </>
+  ),
+} as const;
 
-export function FixtureOverview() {
+const labels = ["Person", "Trip", "Project"] as const;
+type Fixture = "person" | "trip" | "project";
+
+export function FixtureOverview({ fixture }: { fixture?: Fixture }) {
   const [active, setActive] = useState(0);
   const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
@@ -404,9 +456,10 @@ export function FixtureOverview() {
   }, []);
 
   useEffect(() => {
+    if (fixture) return;
     timerRef.current = setInterval(advance, 5000);
     return () => clearInterval(timerRef.current);
-  }, [advance]);
+  }, [advance, fixture]);
 
   const goTo = useCallback(
     (i: number) => {
@@ -417,6 +470,23 @@ export function FixtureOverview() {
     [advance],
   );
 
+  if (fixture) {
+    return (
+      <div className="not-prose">
+        <div
+          className="relative w-full rounded-xl aspect-[16/10] bg-cover bg-center overflow-hidden"
+          style={{ backgroundImage: "url('/evals-wallpaper.jpg')" }}
+        >
+          <MenuBar />
+          <div className="absolute inset-0">{scenes[fixture]}</div>
+          <Dock />
+        </div>
+      </div>
+    );
+  }
+
+  const order: Fixture[] = ["person", "trip", "project"];
+
   return (
     <div className="not-prose flex flex-col items-center gap-3">
       <div
@@ -425,59 +495,14 @@ export function FixtureOverview() {
       >
         <MenuBar />
 
-        {/* Person */}
-        <div
-          className={`absolute inset-0 transition-opacity duration-700 ${active === 0 ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-        >
-          <AppWindow className="left-[4%] top-[16%] w-[36%] h-[52%] z-10">
-            <InstagramContent />
-          </AppWindow>
-          <AppWindow className="left-[24%] top-[12%] w-[42%] h-[56%] z-20">
-            <PhotosContent />
-          </AppWindow>
-          <AppWindow className="left-[52%] top-[10%] w-[26%] h-[62%] z-30">
-            <WhatsAppContent />
-          </AppWindow>
-          <AppWindow className="left-[68%] top-[16%] w-[24%] h-[56%] z-40">
-            <MessagesContent />
-          </AppWindow>
-          <div className="absolute left-[6%] top-[52%] w-[30%] z-50">
-            <ClaudeCodeMini />
+        {order.map((key, i) => (
+          <div
+            key={key}
+            className={`absolute inset-0 transition-opacity duration-700 ${active === i ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          >
+            {scenes[key]}
           </div>
-        </div>
-
-        {/* Trip */}
-        <div
-          className={`absolute inset-0 transition-opacity duration-700 ${active === 1 ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-        >
-          <AppWindow className="left-[4%] top-[12%] w-[46%] h-[60%] z-10">
-            <PhotosContent />
-          </AppWindow>
-          <AppWindow className="left-[34%] top-[16%] w-[38%] h-[56%] z-20">
-            <MapsContent />
-          </AppWindow>
-          <AppWindow className="left-[62%] top-[10%] w-[30%] h-[58%] z-30">
-            <TransactionsContent />
-          </AppWindow>
-          <div className="absolute left-[6%] top-[52%] w-[30%] z-40">
-            <ClaudeCodeMini />
-          </div>
-        </div>
-
-        {/* Project */}
-        <div
-          className={`absolute inset-0 transition-opacity duration-700 ${active === 2 ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-        >
-          <AppWindow className="left-[6%] top-[12%] w-[44%] h-[62%] z-10">
-            <SlackContent />
-          </AppWindow>
-          <AppWindow className="left-[42%] top-[10%] w-[42%] h-[58%] z-20">
-            <GitHubContent />
-          </AppWindow>
-          <div className="absolute left-[10%] top-[50%] w-[32%] z-30">
-            <ClaudeCodeMini />
-          </div>
-        </div>
+        ))}
 
         <Dock />
       </div>

--- a/web/content/docs/choosing-harness-and-model.mdx
+++ b/web/content/docs/choosing-harness-and-model.mdx
@@ -1,21 +1,19 @@
 ---
 title: Choosing a Harness and Model
-description: "Benchmarks, graders, and scores for agent harnesses"
+description: "Benchmarks and scores to help pick the best agent harness and model"
 ---
 
-Running evals across different harness and model combinations for different kinds of editorial work has revealed which ones are better than others. Each eval is fully automated: the agent receives a task, source directories, and a fresh MediaWiki instance, then builds pages across six checkpoints. Output is graded against rubrics and a human-written reference.
+Which harness and model combination produces the best wiki pages? To find out, we run the same eval across every pairing: the agent gets a task, source directories, and a fresh MediaWiki instance, then builds pages through a six-checkpoint editorial workflow. Output is graded against rubrics and a human-written reference. For full details on the protocol, graders, and scoring, see [Evals Suite](/docs/evals-suite).
 
-<FixtureOverview />
+The tables below show the best run per harness and model. Scores are **calibrated** — false penalties from misnumbered citation targets, Talk page editorial notes misclassified as unsupported claims, and partial evidence matches are removed before computing composites.
 
-## Results
+## Person
 
-Best run per harness and model. All runs use the six-checkpoint incremental protocol described below. Accuracy scores are **calibrated**: false penalties are removed where the grader penalized correct facts due to misnumbered citation targets, Talk page editorial notes misclassified as unsupported claims, or partial evidence matches where the core fact is confirmed. Composites are recomputed from calibrated accuracy.
-
-### Person fixture
+<FixtureOverview fixture="person" />
 
 Person page from messaging archives. Two source types, roughly 10k messages.
 
-#### Overall composite
+### Overall composite
 
 <ScoreTable
   headers='["Harness", "Model", "Duration", "Composite"]'
@@ -23,25 +21,27 @@ Person page from messaging archives. Two source types, roughly 10k messages.
   scoreStart={3}
 />
 
-#### Person page
+### Person page
 
 <ScoreTable
   headers='["Harness", "Model", "Compl.", "Cite", "Ref.", "Acc.", "Edit.", "X-ref", "Integ.", "Composite"]'
-  rows='[["CC", "Opus 4.6", "1.000", "0.950", "0.733", "0.890", "0.650", "1.000", "1.000", "0.867"], ["OC", "Opus 4.6", "1.000", "0.900", "0.717", "0.920", "0.350", "1.000", "1.000", "0.838"], ["CX", "GPT-5.2", "0.737", "0.950", "0.533", "0.990", "0.900", "1.000", "0.850", "0.826"], ["CX", "GPT-5.3", "0.632", "0.900", "0.500", "0.960", "0.450", "1.000", "1.000", "0.767"], ["CX", "GPT-5.4", "0.579", "0.900", "0.522", "0.974", "0.400", "1.000", "1.000", "0.765"], ["CC", "Opus 4.5", "0.763", "0.700", "0.617", "0.933", "0.100", "1.000", "1.000", "0.754"], ["CU", "Composer 2", "0.842", "1.000", "0.300", "0.984", "0.550", "1.000", "1.000", "0.760"], ["OC", "Kimi K2.5", "0.658", "0.539", "0.550", "0.846", "0.000", "1.000", "—", "0.617"]]'
+  rows='[["CC", "Opus 4.6", "1.000", "0.950", "0.733", "0.890", "0.650", "1.000", "1.000", "0.867"], ["OC", "Opus 4.6", "1.000", "0.900", "0.717", "0.920", "0.350", "1.000", "1.000", "0.838"], ["CX", "GPT-5.2", "0.737", "0.950", "0.533", "0.990", "0.900", "1.000", "0.850", "0.826"], ["CX", "GPT-5.3", "0.632", "0.900", "0.500", "0.960", "0.450", "1.000", "1.000", "0.767"], ["CX", "GPT-5.4", "0.579", "0.900", "0.522", "0.974", "0.400", "1.000", "1.000", "0.765"], ["CC", "Opus 4.5", "0.763", "0.700", "0.617", "0.933", "0.100", "1.000", "1.000", "0.754"], ["CU", "Composer 2", "0.842", "1.000", "0.300", "0.984", "0.550", "1.000", "1.000", "0.760"], ["OC", "Kimi K2.5", "0.658", "0.539", "0.550", "0.846", "0.000", "1.000", "\u2014", "0.617"]]'
 />
 
-#### Talk page
+### Talk page
 
 <ScoreTable
   headers='["Harness", "Model", "Compl.", "Ref.", "Edit.", "Composite"]'
   rows='[["CX", "GPT-5.3", "0.786", "0.829", "1.000", "0.853"], ["CC", "Opus 4.5", "1.000", "0.714", "0.800", "0.784"], ["CX", "GPT-5.4", "0.786", "0.700", "1.000", "0.772"], ["CC", "Opus 4.6", "1.000", "0.629", "0.800", "0.731"], ["OC", "Opus 4.6", "0.786", "0.600", "0.800", "0.672"], ["CX", "GPT-5.2", "0.786", "0.657", "0.400", "0.633"], ["CU", "Composer 2", "0.286", "0.400", "0.700", "0.435"], ["OC", "Kimi K2.5", "0.500", "0.600", "0.000", "0.469"]]'
 />
 
-### Trip fixture
+## Trip
+
+<FixtureOverview fixture="trip" />
 
 Episode page from a trip combining location history, photos, messages, transactions, Shazam history, and flight records. Six source types.
 
-#### Overall composite
+### Overall composite
 
 <ScoreTable
   headers='["Harness", "Model", "Duration", "Composite"]'
@@ -49,18 +49,28 @@ Episode page from a trip combining location history, photos, messages, transacti
   scoreStart={3}
 />
 
-#### Episode page
+### Episode page
 
 <ScoreTable
   headers='["Harness", "Model", "Compl.", "Cite", "Ref.", "Acc.", "Edit.", "X-ref", "Integ.", "Composite"]'
-  rows='[["CC", "Opus 4.5", "0.711", "0.750", "—", "0.955", "0.400", "1.000", "—", "0.827"], ["OC", "Opus 4.6", "0.789", "0.700", "0.400", "0.937", "0.900", "1.000", "1.000", "0.783"], ["CC", "Opus 4.6", "0.868", "1.000", "0.467", "0.817", "0.650", "1.000", "1.000", "0.773"], ["CX", "GPT-5.3", "0.763", "1.000", "0.364", "0.926", "0.700", "1.000", "0.850", "0.754"], ["CX", "GPT-5.4", "0.763", "1.000", "0.290", "0.972", "0.550", "1.000", "1.000", "0.747"], ["CU", "Composer 2", "0.553", "1.000", "0.297", "0.887", "0.050", "1.000", "1.000", "0.656"], ["CX", "GPT-5.2", "0.500", "0.900", "0.133", "0.758", "0.550", "1.000", "0.550", "0.576"], ["OC", "Kimi K2.5", "0.605", "0.531", "0.456", "—", "0.050", "1.000", "—", "0.495"]]'
+  rows='[["CC", "Opus 4.5", "0.711", "0.750", "\u2014", "0.955", "0.400", "1.000", "\u2014", "0.827"], ["OC", "Opus 4.6", "0.789", "0.700", "0.400", "0.937", "0.900", "1.000", "1.000", "0.783"], ["CC", "Opus 4.6", "0.868", "1.000", "0.467", "0.817", "0.650", "1.000", "1.000", "0.773"], ["CX", "GPT-5.3", "0.763", "1.000", "0.364", "0.926", "0.700", "1.000", "0.850", "0.754"], ["CX", "GPT-5.4", "0.763", "1.000", "0.290", "0.972", "0.550", "1.000", "1.000", "0.747"], ["CU", "Composer 2", "0.553", "1.000", "0.297", "0.887", "0.050", "1.000", "1.000", "0.656"], ["CX", "GPT-5.2", "0.500", "0.900", "0.133", "0.758", "0.550", "1.000", "0.550", "0.576"], ["OC", "Kimi K2.5", "0.605", "0.531", "0.456", "\u2014", "0.050", "1.000", "\u2014", "0.495"]]'
 />
 
-#### Talk page
+### Talk page
 
 <ScoreTable
   headers='["Harness", "Model", "Compl.", "Ref.", "Edit.", "Composite"]'
-  rows='[["CC", "Opus 4.5", "0.786", "—", "0.500", "0.643"], ["CX", "GPT-5.4", "0.786", "0.400", "0.850", "0.557"], ["CX", "GPT-5.3", "0.786", "0.400", "0.800", "0.547"], ["CC", "Opus 4.6", "0.786", "0.400", "0.600", "0.510"], ["OC", "Kimi K2.5", "0.786", "0.400", "0.550", "0.500"], ["CU", "Composer 2", "0.714", "0.200", "1.000", "0.446"], ["OC", "Opus 4.6", "0.786", "0.200", "0.800", "0.422"], ["CX", "GPT-5.2", "0.786", "0.200", "0.800", "0.422"]]'
+  rows='[["CC", "Opus 4.5", "0.786", "\u2014", "0.500", "0.643"], ["CX", "GPT-5.4", "0.786", "0.400", "0.850", "0.557"], ["CX", "GPT-5.3", "0.786", "0.400", "0.800", "0.547"], ["CC", "Opus 4.6", "0.786", "0.400", "0.600", "0.510"], ["OC", "Kimi K2.5", "0.786", "0.400", "0.550", "0.500"], ["CU", "Composer 2", "0.714", "0.200", "1.000", "0.446"], ["OC", "Opus 4.6", "0.786", "0.200", "0.800", "0.422"], ["CX", "GPT-5.2", "0.786", "0.200", "0.800", "0.422"]]'
+/>
+
+## Overall
+
+Combined composite averaging Person and Trip fixture scores for each harness and model.
+
+<ScoreTable
+  headers='["Harness", "Model", "Duration", "Person", "Trip", "Overall"]'
+  rows='[["Claude Code", "Opus 4.6", "3h 58m", "0.828", "0.745", "0.787"], ["Codex", "GPT-5.3", "4h 8m", "0.761", "0.761", "0.761"], ["Claude Code", "Opus 4.5", "2h 6m", "0.743", "0.774", "0.759"], ["Codex", "GPT-5.4", "5h 56m", "0.766", "0.737", "0.752"], ["OpenCode", "Opus 4.6", "3h 40m", "0.803", "0.652", "0.728"], ["Codex", "GPT-5.2", "4h 38m", "0.770", "0.632", "0.701"], ["Cursor", "Composer 2", "2h 36m", "0.722", "0.640", "0.681"], ["OpenCode", "Kimi K2.5", "2h 27m", "0.624", "0.460", "0.542"]]'
+  scoreStart={3}
 />
 
 ## Observations
@@ -79,54 +89,3 @@ Episode page from a trip combining location history, photos, messages, transacti
 - **Six source types stress integration.** With location history, photos, messages, transactions, Shazam, and flights, agents must synthesize across more data types than the person fixture. Cross-referencing still hits 1.000 across the board, but reference scores are notably lower (0.133–0.467 vs 0.300–0.733 for person).
 - **OpenCode benefits from permission fix.** After correcting filesystem permission rules, OpenCode Opus 4.6 jumped from 0.000 to 0.652 and scored the highest editorial mark (0.900) of any agent on either fixture.
 - **Talk pages are weaker across the board.** The best trip talk page (CC Opus 4.5 at 0.643) trails the best person talk page (CX GPT-5.3 at 0.853). Reference scores are particularly low, suggesting agents don't structure editorial discussion as thoroughly for episode pages.
-
-## Protocol
-
-Each eval uses a six-checkpoint editorial workflow that mirrors how a human editor would build a wiki page from raw data.
-
-1. **Survey**: Snapshot a source directory and create a `Source:` page. Catalog media, transcribe voice notes, assess data quality and gaps. Plan the editorial approach.
-2. **Draft**: Write the person or episode page using only the first source. Include an infobox, lead paragraph, sections with prose and citations. Note episode candidates and gaps on the Talk page.
-3. **New source**: Snapshot a second source directory and create its source page. Revise the existing article by weaving new data into the right sections rather than appending. Cross-reference facts across sources. Update the Talk page.
-4. **Episodes**: Create episode pages for rich narratives: first meetings, trips, conflicts, milestones. Link each from the main page with a one-sentence summary.
-5. **Owner input**: Integrate first-person testimony from the wiki owner. Cite using `{{Cite testimony}}`. Where testimony conflicts with digital evidence, note the discrepancy on the Talk page.
-6. **Verify**: Final editorial review. Audit tone, balance, and gaps. Produce a citation manifest pairing every factual claim with its source evidence.
-
-A fresh MediaWiki instance is provisioned per run with templates and no content pages. The agent's conversation is resumed between checkpoints so it can build on prior work.
-
-## Graders
-
-Nine graders organized into three weighted tiers.
-
-### Quality (50%)
-
-**Reference** compares output against a human-written reference page. Measures section heading overlap, infobox field coverage, citation hash density, and category overlap. Each dimension is weighted and combined into a single score.
-
-**Accuracy** resolves the citation manifest produced at the verify checkpoint. For each claim, it checks whether the cited source evidence actually supports it. Claims are classified as supported, unsupported, or fabricated. Fabrications carry a 2x penalty. Owner testimony cited with `{{Cite testimony}}` is classified as "attributed" rather than unsupported.
-
-### Content (30%)
-
-**Completeness** checks structural elements: lead paragraph, infobox, body sections, `References` and `Bibliography` sections, categories, prose word count, subsection count, inline citations, blockquotes, and media embeds. Thresholds scale with checkpoint so earlier checkpoints have lower requirements.
-
-**Editorial** is an LLM-graded evaluation of Wikipedia editorial conventions: neutral third-person tone, past tense for biographical events, section organization, prose quality, wikitext syntax, and wikilink usage. Uses multi-pass grading with median scoring.
-
-**Integration** measures revision quality when a page is updated across checkpoints. Checks whether new facts land in the right existing sections, whether the page reads as a unified article after revision, and whether conflicting data is noted on the Talk page. Only scored when the page content has changed since the previous checkpoint.
-
-**Source criticism** evaluates whether source pages include critical assessment beyond raw statistics: platform limitation notes, gap identification, data quality assessment, querying instructions, and content breakdowns. LLM-graded.
-
-### Mechanics (20%)
-
-**Citations** validates citation templates (`{{Cite message}}`, `{{Cite vault}}`, `{{Cite testimony}}`, etc.) for required fields. Each template type has specific requirements: `snapshot` and `date` for digital sources, `speaker` and `date` for testimony. Score is valid citations over total.
-
-**Cross-referencing** measures whether the page combines information from multiple source types. Counts facts that synthesize data across sources versus possible cross-references. Only scored when two or more source types are present.
-
-**Tool usage** checks harness logs for expected CLI calls: `wai snapshot`, `wai read`, `wai write`/`create`/`edit`. Binary per tool.
-
-### Composite
-
-```
-page_composite = 0.5 * quality + 0.3 * content + 0.2 * mechanics
-```
-
-Within each tier, weight is split equally among the graders that produced a score. If an entire tier is absent, its weight redistributes proportionally to the tiers that are present.
-
-The overall run composite splits 20% source pages (averaged) and 80% content pages. Content pages are weighted: person 85% + talk 15% when no episodes exist, or person 50% + episodes 40% + talk 10% when they do.

--- a/web/content/docs/evals-suite.mdx
+++ b/web/content/docs/evals-suite.mdx
@@ -1,0 +1,59 @@
+---
+title: Evals Suite
+description: "Protocol, graders, and scoring methodology for agent evals"
+---
+
+Each eval is fully automated: the agent receives a task, source directories, and a fresh MediaWiki instance, then builds pages across six checkpoints. Output is graded against rubrics and a human-written reference. Accuracy scores are **calibrated**: false penalties are removed where the grader penalized correct facts due to misnumbered citation targets, Talk page editorial notes misclassified as unsupported claims, or partial evidence matches where the core fact is confirmed. Composites are recomputed from calibrated accuracy.
+
+For results across harness and model combinations, see [Choosing a Harness and Model](/docs/choosing-harness-and-model).
+
+## Protocol
+
+Each eval uses a six-checkpoint editorial workflow that mirrors how a human editor would build a wiki page from raw data.
+
+1. **Survey**: Snapshot a source directory and create a `Source:` page. Catalog media, transcribe voice notes, assess data quality and gaps. Plan the editorial approach.
+2. **Draft**: Write the person or episode page using only the first source. Include an infobox, lead paragraph, sections with prose and citations. Note episode candidates and gaps on the Talk page.
+3. **New source**: Snapshot a second source directory and create its source page. Revise the existing article by weaving new data into the right sections rather than appending. Cross-reference facts across sources. Update the Talk page.
+4. **Episodes**: Create episode pages for rich narratives: first meetings, trips, conflicts, milestones. Link each from the main page with a one-sentence summary.
+5. **Owner input**: Integrate first-person testimony from the wiki owner. Cite using `{{Cite testimony}}`. Where testimony conflicts with digital evidence, note the discrepancy on the Talk page.
+6. **Verify**: Final editorial review. Audit tone, balance, and gaps. Produce a citation manifest pairing every factual claim with its source evidence.
+
+A fresh MediaWiki instance is provisioned per run with templates and no content pages. The agent's conversation is resumed between checkpoints so it can build on prior work.
+
+## Graders
+
+Nine graders organized into three weighted tiers.
+
+### Quality (50%)
+
+**Reference** compares output against a human-written reference page. Measures section heading overlap, infobox field coverage, citation hash density, and category overlap. Each dimension is weighted and combined into a single score.
+
+**Accuracy** resolves the citation manifest produced at the verify checkpoint. For each claim, it checks whether the cited source evidence actually supports it. Claims are classified as supported, unsupported, or fabricated. Fabrications carry a 2x penalty. Owner testimony cited with `{{Cite testimony}}` is classified as "attributed" rather than unsupported.
+
+### Content (30%)
+
+**Completeness** checks structural elements: lead paragraph, infobox, body sections, `References` and `Bibliography` sections, categories, prose word count, subsection count, inline citations, blockquotes, and media embeds. Thresholds scale with checkpoint so earlier checkpoints have lower requirements.
+
+**Editorial** is an LLM-graded evaluation of Wikipedia editorial conventions: neutral third-person tone, past tense for biographical events, section organization, prose quality, wikitext syntax, and wikilink usage. Uses multi-pass grading with median scoring.
+
+**Integration** measures revision quality when a page is updated across checkpoints. Checks whether new facts land in the right existing sections, whether the page reads as a unified article after revision, and whether conflicting data is noted on the Talk page. Only scored when the page content has changed since the previous checkpoint.
+
+**Source criticism** evaluates whether source pages include critical assessment beyond raw statistics: platform limitation notes, gap identification, data quality assessment, querying instructions, and content breakdowns. LLM-graded.
+
+### Mechanics (20%)
+
+**Citations** validates citation templates (`{{Cite message}}`, `{{Cite vault}}`, `{{Cite testimony}}`, etc.) for required fields. Each template type has specific requirements: `snapshot` and `date` for digital sources, `speaker` and `date` for testimony. Score is valid citations over total.
+
+**Cross-referencing** measures whether the page combines information from multiple source types. Counts facts that synthesize data across sources versus possible cross-references. Only scored when two or more source types are present.
+
+**Tool usage** checks harness logs for expected CLI calls: `wai snapshot`, `wai read`, `wai write`/`create`/`edit`. Binary per tool.
+
+### Composite
+
+```
+page_composite = 0.5 * quality + 0.3 * content + 0.2 * mechanics
+```
+
+Within each tier, weight is split equally among the graders that produced a score. If an entire tier is absent, its weight redistributes proportionally to the tiers that are present.
+
+The overall run composite splits 20% source pages (averaged) and 80% content pages. Content pages are weighted: person 85% + talk 15% when no episodes exist, or person 50% + episodes 40% + talk 10% when they do.

--- a/web/lib/docs-sidebar-config.ts
+++ b/web/lib/docs-sidebar-config.ts
@@ -49,6 +49,7 @@ const sidebarLayout: SidebarSectionConfig[] = [
     title: "Reference",
     items: [
       { title: "CLI", slug: "cli" },
+      { title: "Evals Suite", slug: "evals-suite" },
       { title: "Glossary", slug: "glossary" },
     ],
   },


### PR DESCRIPTION
## Summary

- Splits the choosing-harness-and-model page into a results-focused guide and a separate **Evals Suite** reference page under Reference in the sidebar
- Reorders the results page as Person, Trip, Overall (with a new cross-fixture composite table)
- Replaces the carousel `FixtureOverview` with per-fixture static visuals under each section heading
- Moves protocol, graders, and composite scoring methodology to `/docs/evals-suite`

## Test plan

- [x] Verify `/docs/choosing-harness-and-model` renders Person, Trip, Overall sections with fixture visuals
- [x] Verify `/docs/evals-suite` renders protocol, graders, and composite sections
- [x] Verify sidebar shows Evals Suite under Reference
- [x] Verify cross-links between both pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)