### PR TITLE
fix: overwrite stock main page during fresh install

### DIFF
--- a/desktop/src/setup.ts
+++ b/desktop/src/setup.ts
@@ -173,8 +173,8 @@ export async function runSetup(
     "Initial styles import",
   );
 
-  // Create Main Page
-  await createPage(
+  // Overwrite the stock Main Page created by the install script
+  await editPage(
     apiUrl,
     csrfToken,
     "Main Page",
@@ -593,6 +593,26 @@ function apiPost(apiUrl: string, params: Record<string, string>): Promise<any> {
     request.write(body);
     request.end();
   });
+}
+
+async function editPage(
+  apiUrl: string,
+  token: string,
+  title: string,
+  content: string,
+  summary: string,
+): Promise<void> {
+  const result = await apiPost(apiUrl, {
+    action: "edit",
+    title,
+    text: content,
+    summary,
+    token,
+    format: "json",
+  });
+  if (result?.error) {
+    console.error(`[setup] Failed to edit ${title}:`, result.error);
+  }
 }
 
 async function createPage(


### PR DESCRIPTION
## Summary

- The MediaWiki `install` script creates a default "Main Page" during database setup. The setup code then tried to create the custom Main Page with `createonly: true`, which silently failed because the page already existed.
- Added an `editPage` helper (without `createonly`) and use it for the Main Page so the custom content overwrites the stock page.

## Test plan

- [x] Fresh install on a clean machine — verify the custom welcome page appears instead of the stock MediaWiki Main Page
- [x] Existing install — verify launch still works normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)