### PR TITLE
feat: improve cli auth messages

### DIFF
--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -102,6 +102,8 @@ async function status(globals: GlobalFlags): Promise<void> {
     } else {
       console.log(`Status:    not configured`);
       console.log(`           ${e.message}`);
+      console.log('');
+      console.log('Tip: Make sure the whoami desktop app is running to authenticate.');
     }
   }
 }

--- a/web/app/cli/install.sh/route.ts
+++ b/web/app/cli/install.sh/route.ts
@@ -93,7 +93,7 @@ case ":\$PATH:" in
     ;;
 esac
 
-info "Run 'wai auth login' to get started."
+info "Installation complete."
 `;
 
 export function GET() {


### PR DESCRIPTION
## Summary
- Remove "Run 'wai auth login' to get started" message from the CLI install script, replacing it with a simple "Installation complete."
- When `wai auth status` is run and credentials are not configured, show a tip telling the user that the whoami desktop app needs to be running to authenticate.

## Test plan
- [x] Run the install script and verify it no longer shows the old "Run 'wai auth login'" message
- [x] Run `wai auth status` without credentials configured and verify the desktop app tip is shown
- [x] Run `wai auth status --json` without credentials and verify JSON output is unchanged

https://claude.ai/code/session_01UqzSHsGAG4iNwjFsMHUzR3