### PR TITLE
fix: use solid background for frozen column in dark mode

### DIFF
--- a/web/components/score-table.tsx
+++ b/web/components/score-table.tsx
@@ -66,7 +66,7 @@ export function ScoreTable({
                       isBest
                         ? `py-2.5 px-3 font-medium text-green-700 dark:text-green-400${frozen ? "" : " bg-green-50 dark:bg-green-950/30"}`
                         : "py-2.5 px-3 text-neutral-600 dark:text-neutral-400"
-                    } border-b${ci < scoreStart ? " whitespace-nowrap" : " text-right tabular-nums"}${frozen ? ` ${stickyClass}${isBest ? " !bg-green-50 dark:!bg-green-900/40" : ""}` : ""}`}
+                    } border-b${ci < scoreStart ? " whitespace-nowrap" : " text-right tabular-nums"}${frozen ? ` ${stickyClass}${isBest ? " !bg-green-50 dark:!bg-[#243d2e]" : ""}` : ""}`}
                   >
                     {cell}
                   </td>


### PR DESCRIPTION
## Summary
- The frozen (sticky) "Composite" column in the score table used a semi-transparent background (`green-900/40`) for best-score highlights in dark mode
- This caused scrolling content to bleed through the frozen column
- Replaced with an opaque equivalent color (`#243d2e`) computed from green-900 at 40% over the `#2e2e2e` dark background

## Test plan
- [x] Open /docs/choosing-harness-and-model in dark mode
- [x] Scroll the score table horizontally
- [x] Verify the frozen "Composite" column has a solid background with no content showing through

https://claude.ai/code/session_012QfJhnyqJwJ4GYxEFvduEB