### PR TITLE
fix: correct github issues link in desktop main page

### DIFF
--- a/desktop/resources/templates/Main_Page.wiki
+++ b/desktop/resources/templates/Main_Page.wiki
@@ -19,6 +19,6 @@ Your job is simple: point the agent at your data (old chats, photos, notes, what
 
 == Need help? ==
 
-If something breaks or feels wrong, open an issue at [https://github.com/anthropics/whoami-wiki/issues github.com/anthropics/whoami-wiki/issues]. We read every one.
+If something breaks or feels wrong, open an issue at [https://github.com/whoami-wiki/whoami/issues github.com/whoami-wiki/whoami/issues]. We read every one.
 
 </div>


### PR DESCRIPTION
## Summary
- Fix incorrect GitHub issues URL in the desktop app's custom Main Page template
- Changed `github.com/anthropics/whoami-wiki/issues` to `github.com/whoami-wiki/whoami/issues`

## Test plan
- [ ] Verify the link in the desktop app's Main Page points to the correct repository

https://claude.ai/code/session_01U8XJCZqh3MMhJUbiaT3DEF