### PR TITLE
fix: preserve local date in blog post display to avoid utc shift

### DIFF
--- a/web/app/blog/[slug]/page.tsx
+++ b/web/app/blog/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getAllPosts, getPost } from "@/lib/blog";
+import { getAllPosts, getPost, formatBlogDate } from "@/lib/blog";
 import { MDXContent } from "@/components/mdx-content";
 import Image from "next/image";
 
@@ -60,11 +60,7 @@ export default async function BlogPostPage({ params }: Props) {
             className="font-sans text-base text-neutral-500 dark:text-neutral-400"
             dateTime={post.date}
           >
-            {new Date(post.date).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
+            {formatBlogDate(post.date)}
           </time>
         </div>
 

--- a/web/app/blog/page.tsx
+++ b/web/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { getAllPosts } from "@/lib/blog";
+import { getAllPosts, formatBlogDate } from "@/lib/blog";
 
 export const metadata: Metadata = {
   title: "Blog — whoami.wiki",
@@ -44,11 +44,7 @@ export default function BlogPage() {
                   className="font-sans text-base text-neutral-500 dark:text-neutral-400"
                   dateTime={post.date}
                 >
-                  {new Date(post.date).toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })}
+                  {formatBlogDate(post.date)}
                 </time>
               </div>
               <Image

--- a/web/lib/blog.ts
+++ b/web/lib/blog.ts
@@ -38,6 +38,19 @@ export interface TocHeading {
   level: number;
 }
 
+/** Format a blog post date string, preserving the local date from the ISO string to avoid UTC shift. */
+export function formatBlogDate(dateStr: string): string {
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return dateStr;
+  const [, year, month, day] = match;
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
 export function slugify(text: string): string {
   return text
     .toLowerCase()


### PR DESCRIPTION
## Summary

- Blog post dates with timezone offsets (e.g. `2026-03-25T18:00:00-07:00`) were being converted to UTC during SSR, causing the displayed date to shift forward by a day (showing March 26 instead of March 25)
- Added `formatBlogDate()` helper that parses the local date directly from the ISO string, avoiding UTC conversion
- Applied the fix to both the blog listing page and individual blog post page

## Test plan

- [ ] Verify the "Personal Encyclopedias" blog post shows "March 25, 2026" instead of "March 26, 2026"
- [ ] Verify the blog listing page also shows the correct date

https://claude.ai/code/session_01XqWwzZQ526rTrzEmLi6iuu